### PR TITLE
feat: support for organization discovery strategies

### DIFF
--- a/packages/javascript/src/index.ts
+++ b/packages/javascript/src/index.ts
@@ -86,6 +86,8 @@ export {
   SignInOptions,
   SignOutOptions,
   SignUpOptions,
+  OrganizationDiscovery,
+  OrganizationDiscoveryStrategy,
 } from './models/config';
 export {TokenResponse, IdToken, TokenExchangeRequestConfig} from './models/token';
 export {Crypto, JWKInterface} from './models/crypto';
@@ -143,7 +145,7 @@ export {default as resolveFieldName} from './utils/resolveFieldName';
 export {default as processOpenIDScopes} from './utils/processOpenIDScopes';
 export {default as withVendorCSSClassPrefix} from './utils/withVendorCSSClassPrefix';
 export {default as transformBrandingPreferenceToTheme} from './utils/transformBrandingPreferenceToTheme';
-
+export {default as organizationDiscovery} from './utils/organizationDiscovery';
 export {
   default as logger,
   createLogger,

--- a/packages/javascript/src/utils/organizationDiscovery.ts
+++ b/packages/javascript/src/utils/organizationDiscovery.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {OrganizationDiscoveryStrategy} from '../models/config';
+import deriveOrganizationHandleFromBaseUrl from './deriveOrganizationHandleFromBaseUrl';
+
+/**
+ * Derives organization info from URL path parameter
+ * Supports patterns like /o/<handle> or /<param>/<handle>
+ */
+const deriveFromUrlPath = (param: string): string | undefined => {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.window !== 'undefined') {
+    const pathSegments = globalThis.window.location.pathname.split('/').filter(segment => segment);
+
+    // Look for the parameter in the path segments
+    const paramIndex = pathSegments.findIndex(segment => segment === param);
+
+    if (paramIndex !== -1 && paramIndex + 1 < pathSegments.length) {
+      return pathSegments[paramIndex + 1];
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Derives organization info from URL query parameter
+ */
+const deriveFromUrlQuery = (param: string): string | undefined => {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.window !== 'undefined') {
+    const urlParams = new URLSearchParams(globalThis.window.location.search);
+    return urlParams.get(param) || undefined;
+  }
+
+  return undefined;
+};
+
+/**
+ * Derives organization info from subdomain
+ */
+const deriveFromSubdomain = (): string | undefined => {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.window !== 'undefined') {
+    const hostname = globalThis.window.location.hostname;
+    const parts = hostname.split('.');
+
+    // Return first part if it's not 'www' and has at least 3 parts (subdomain.domain.tld)
+    if (parts.length >= 3 && parts[0] !== 'www') {
+      return parts[0];
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Resolves organization info based on the discovery strategy
+ */
+const organizationDiscovery = async (
+  strategy: OrganizationDiscoveryStrategy,
+  baseUrl?: string,
+): Promise<string | undefined> => {
+  const resolvedStrategy = strategy || {
+    type: 'baseUrl',
+    param: undefined,
+    resolver: () => null,
+  };
+
+  switch (resolvedStrategy?.type) {
+    case 'baseUrl':
+      return deriveOrganizationHandleFromBaseUrl(baseUrl);
+
+    case 'urlPath':
+      return deriveFromUrlPath(resolvedStrategy?.param);
+
+    case 'urlQuery':
+      return deriveFromUrlQuery(resolvedStrategy?.param);
+
+    case 'subdomain':
+      return deriveFromSubdomain();
+
+    case 'custom':
+      return await resolvedStrategy?.resolver();
+
+    default:
+      return undefined;
+  }
+};
+
+export default organizationDiscovery;


### PR DESCRIPTION
### Purpose
This PR implements automatic **Organization Discovery Strategies** for the Asgardeo SDK, enabling seamless extraction of organization handles from URLs without manual configuration. The feature supports multiple discovery strategies (`urlPath`, `urlQuery`, `subdomain`, `baseUrl`, `custom`) and automatically injects the discovered organization into authentication requests as `signInOptions={{ fidp: 'OrganizationSSO', orgId: '<discovered_org>' }}`.

**Key Features:**
- ✅ Strategy-based organization discovery system
- ✅ Support for 5 discovery strategies with automatic fallback
- ✅ React and Next.js client integration
- ✅ Backward compatible - existing `organizationHandle` config takes precedence
- ✅ TypeScript support with comprehensive type definitions
- ✅ Graceful error handling and debugging support

**Implementation Details:**
- Core discovery utility in `@asgardeo/javascript` package
- Automatic integration in `AsgardeoReactClient.initialize()` method
- Browser-safe URL parsing with SSR compatibility
- Comprehensive error handling with console warnings
- Loading state management fixes for React providers

### Related Issues
- https://github.com/asgardeo/javascript/issues/124

### Related PRs
- N/A

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [x] Documentation provided. (Feature issue with comprehensive examples and usage patterns)
- [x] Unit tests provided. (Organization discovery utility tests)
- [x] Integration tests provided. (React client integration tests)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?