### PR TITLE
ci: Add change set checker workflow

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -29,7 +29,7 @@ on:
             - completed
 
 env:
-    GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+    GH_TOKEN: ${{ secrets.ASGARDEO_GITHUB_BOT_TOKEN }}
     IS_RELEASE_MODE: false
 
 jobs:

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -51,117 +51,117 @@ jobs:
               run: cat ./PR_NUMBER
 
             - name: 💬 Remove Existing Changeset Comment
-              uses: actions/github-script@v3.1.0
+              uses: actions/github-script@v7
               with:
                 github-token: ${{ env.GH_TOKEN }}
                 script: |
-                    const fs = require('fs');
-                    const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
-                    const REPO_OWNER = context.repo.owner;
-                    const REPO_NAME = context.repo.repo;
+                  const fs = require('fs');
+                  const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
+                  const REPO_OWNER = context.repo.owner;
+                  const REPO_NAME = context.repo.repo;
 
-                    // Fetch all comments on the pull request.
-                    const comments = await github.issues.listComments({
+                  const comments = await github.rest.issues.listComments({
+                    owner: REPO_OWNER,
+                    repo: REPO_NAME,
+                    issue_number: PR_NUMBER,
+                  });
+
+                  console.log("COMMENTS_URL: https://api.github.com/repos/" + REPO_NAME + "/issues/" + PR_NUMBER + "/comments");
+
+                  for (const comment of comments.data) {
+                    console.log("COMMENT_OWNER: " + comment.user.login);
+
+                    if (
+                      comment.body.includes("🦋 Changeset detected") ||
+                      comment.body.includes("⚠️ No Changeset found") ||
+                      comment.body.includes("❌ Invalid Changeset detected")
+                    ) {
+                      console.log("COMMENT_ID_TO_DELETE: " + comment.id);
+
+                      await github.rest.issues.deleteComment({
                         owner: REPO_OWNER,
                         repo: REPO_NAME,
-                        issue_number: PR_NUMBER,
-                    });
-
-                    console.log("COMMENTS_URL: https://api.github.com/repos/" + REPO_NAME + "/issues/" + PR_NUMBER + "/comments");
-
-                    for (const comment of comments.data) {
-                        console.log("COMMENT_OWNER: " + comment.user.login);
-
-                        // Identify the changeset comment by its heading.
-                        if (comment.body.includes("🦋 Changeset detected") || comment.body.includes("⚠️ No Changeset found") || comment.body.includes("❌ Invalid Changeset detected")) {
-                            console.log("COMMENT_ID_TO_DELETE: " + comment.id);
-
-                            // Remove the changeset comment using the comment ID.
-                            await github.issues.deleteComment({
-                                owner: REPO_OWNER,
-                                repo: REPO_NAME,
-                                comment_id: comment.id,
-                            });
-                        }
+                        comment_id: comment.id,
+                      });
                     }
+                  }
 
             - name: 💬 Add Changeset Comment
-              uses: actions/github-script@v3.1.0
+              uses: actions/github-script@v7
               with:
                 github-token: ${{ env.GH_TOKEN }}
                 script: |
-                    const fs = require('fs');
-                    const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
-                    const REPO_OWNER = context.repo.owner;
-                    const REPO_NAME = context.repo.repo;
-                    const IS_RELEASE_MODE = process.env.IS_RELEASE_MODE === 'true';
+                  const fs = require('fs');
+                  const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
+                  const REPO_OWNER = context.repo.owner;
+                  const REPO_NAME = context.repo.repo;
+                  const IS_RELEASE_MODE = process.env.IS_RELEASE_MODE === 'true';
 
-                    const files = await github.pulls.listFiles({
-                        owner: REPO_OWNER,
-                        repo: REPO_NAME,
-                        pull_number: PR_NUMBER,
-                    });
+                  const files = await github.rest.pulls.listFiles({
+                    owner: REPO_OWNER,
+                    repo: REPO_NAME,
+                    pull_number: PR_NUMBER,
+                  });
 
-                    const CHANGED_FILES = files.data.map(file => file.filename);
-                    console.log("CHANGED_FILES_URL: https://api.github.com/repos/" + REPO_NAME + "/pulls/" + PR_NUMBER + "/files");
-                    console.log("CHANGED_FILES:", CHANGED_FILES);
+                  const CHANGED_FILES = files.data.map(file => file.filename);
+                  console.log("CHANGED_FILES_URL: https://api.github.com/repos/" + REPO_NAME + "/pulls/" + PR_NUMBER + "/files");
+                  console.log("CHANGED_FILES:", CHANGED_FILES);
 
-                    const CHANGESET_FILES = CHANGED_FILES.filter(filename => /^\.changeset\/.*\.md$/.test(filename));
-                    const CHANGES_COUNT = CHANGESET_FILES.length;
-                    console.log("CHANGES_COUNT:", CHANGES_COUNT);
-                    console.log("IS_RELEASE_MODE:", IS_RELEASE_MODE);
+                  const CHANGESET_FILES = CHANGED_FILES.filter(filename => /^\.changeset\/.*\.md$/.test(filename));
+                  const CHANGES_COUNT = CHANGESET_FILES.length;
+                  console.log("CHANGES_COUNT:", CHANGES_COUNT);
+                  console.log("IS_RELEASE_MODE:", IS_RELEASE_MODE);
 
-                    let invalidChangesets = [];
+                  let invalidChangesets = [];
 
-                    // Check for major/minor changesets in release mode (master branch)
-                    if (IS_RELEASE_MODE && CHANGES_COUNT > 0) {
-                        for (const changesetFile of CHANGESET_FILES) {
-                            try {
-                                const fileResponse = await github.repos.getContent({
-                                    owner: REPO_OWNER,
-                                    repo: REPO_NAME,
-                                    path: changesetFile,
-                                    ref: `refs/pull/${PR_NUMBER}/head`
-                                });
+                  if (IS_RELEASE_MODE && CHANGES_COUNT > 0) {
+                    for (const changesetFile of CHANGESET_FILES) {
+                      try {
+                        const fileResponse = await github.rest.repos.getContent({
+                          owner: REPO_OWNER,
+                          repo: REPO_NAME,
+                          path: changesetFile,
+                          ref: `refs/pull/${PR_NUMBER}/head`
+                        });
 
-                                const content = Buffer.from(fileResponse.data.content, 'base64').toString('utf8');
-                                console.log("CHANGESET_CONTENT:", changesetFile, content);
+                        const content = Buffer.from(fileResponse.data.content, 'base64').toString('utf8');
+                        console.log("CHANGESET_CONTENT:", changesetFile, content);
 
-                                // Parse changeset frontmatter to check for major/minor releases
-                                const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-                                if (frontmatterMatch) {
-                                    const frontmatter = frontmatterMatch[1];
-                                    if (frontmatter.includes(': major') || frontmatter.includes(': minor')) {
-                                        invalidChangesets.push({
-                                            file: changesetFile,
-                                            type: frontmatter.includes(': major') ? 'major' : 'minor'
-                                        });
-                                    }
-                                }
-                            } catch (error) {
-                                console.log("Error reading changeset file:", changesetFile, error.message);
-                            }
+                        const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+                        if (frontmatterMatch) {
+                          const frontmatter = frontmatterMatch[1];
+                          if (frontmatter.includes(': major') || frontmatter.includes(': minor')) {
+                            invalidChangesets.push({
+                              file: changesetFile,
+                              type: frontmatter.includes(': major') ? 'major' : 'minor'
+                            });
+                          }
                         }
+                      } catch (error) {
+                        console.log("Error reading changeset file:", changesetFile, error.message);
+                      }
                     }
+                  }
 
-                    let COMMENT;
-                    if (CHANGES_COUNT > 0) {
-                        if (IS_RELEASE_MODE && invalidChangesets.length > 0) {
-                            console.log("Invalid changesets detected in release mode:", invalidChangesets);
-                            const invalidFiles = invalidChangesets.map(cs => `- \`${cs.file}\` (${cs.type})`).join('\n');
-                            COMMENT = `<h3>❌ Invalid Changeset detected</h3><p><b>🚀 WSO2 Identity Server release mode is currently activated!</b></p><p>The following changesets contain major/minor versions, but the master branch only allows patch releases:</p>\n${invalidFiles}\n<p><b>📋 Action Required:</b></p><ul><li>🔧 Update these changesets to use patch versions only, OR</li><li>🎯 Target the <code>next</code> branch for minor/major releases</li></ul><p>📚 Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn about our release strategy.</p>`;
-                        } else {
-                            console.log("Changeset detected");
-                            COMMENT = `<h3>🦋 Changeset detected</h3><p><b>The changes in this PR will be included in the next version bump.</b></p><p>Not sure what this means? <a href="https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md">Click here to learn what changesets are</a>.</p>`;
-                        }
+                  let COMMENT;
+                  if (CHANGES_COUNT > 0) {
+                    if (IS_RELEASE_MODE && invalidChangesets.length > 0) {
+                      console.log("Invalid changesets detected in release mode:", invalidChangesets);
+                      const invalidFiles = invalidChangesets.map(cs => `- \`${cs.file}\` (${cs.type})`).join('\n');
+                      COMMENT = `<h3>❌ Invalid Changeset detected</h3><p><b>🚀 WSO2 Identity Server release mode is currently activated!</b></p><p>The following changesets contain major/minor versions, but the master branch only allows patch releases:</p>\n${invalidFiles}\n<p><b>📋 Action Required:</b></p><ul><li>🔧 Update these changesets to use patch versions only, OR</li><li>🎯 Target the <code>next</code> branch for minor/major releases</li></ul><p>📚 Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn about our release strategy.</p>`;
                     } else {
-                        console.log("No changeset detected");
-                        COMMENT = `<h3>⚠️ No Changeset found</h3>Merging this PR will not cause a version bump for any packages. If these changes should not result in a new version, you're good to go.</p><p><b>If these changes should result in a version bump, you need to add a changeset.</b></p><p>Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn how to add a changeset.`;
+                      console.log("Changeset detected");
+                      COMMENT = `<h3>🦋 Changeset detected</h3><p><b>The changes in this PR will be included in the next version bump.</b></p><p>Not sure what this means? <a href="https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md">Click here to learn what changesets are</a>.</p>`;
                     }
+                  } else {
+                    console.log("No changeset detected");
+                    COMMENT = `<h3>⚠️ No Changeset found</h3>Merging this PR will not cause a version bump for any packages. If these changes should not result in a new version, you're good to go.</p><p><b>If these changes should result in a version bump, you need to add a changeset.</b></p><p>Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn how to add a changeset.`;
+                  }
 
-                    await github.issues.createComment({
-                        owner: REPO_OWNER,
-                        repo: REPO_NAME,
-                        issue_number: PR_NUMBER,
-                        body: COMMENT,
-                    });
+                  await github.rest.issues.createComment({
+                    owner: REPO_OWNER,
+                    repo: REPO_NAME,
+                    issue_number: PR_NUMBER,
+                    body: COMMENT,
+                  });
+

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -1,0 +1,167 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+# This workflow will check if a submitted PR has changesets.
+
+name: 🦋 Check for Changeset
+
+on:
+    workflow_run:
+        workflows: ["📩 Receive PR"]
+        types:
+            - completed
+
+env:
+    GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+    IS_RELEASE_MODE: false
+
+jobs:
+    check-changeset:
+        runs-on: ubuntu-latest
+        if: >
+            github.event.workflow_run.event == 'pull_request' &&
+            github.event.workflow_run.conclusion == 'success'
+        steps:
+            - name: 📥 Download PR Number Artifact
+              uses: actions/download-artifact@v4
+              with:
+                name: pr-number
+                github-token: ${{ env.GH_TOKEN }}
+                repository: ${{ github.repository }}
+                run-id: ${{ github.event.workflow_run.id }}
+
+            - name: 📝 Display PR Number
+              run: cat ./PR_NUMBER
+
+            - name: 💬 Remove Existing Changeset Comment
+              uses: actions/github-script@v3.1.0
+              with:
+                github-token: ${{ env.GH_TOKEN }}
+                script: |
+                    const fs = require('fs');
+                    const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
+                    const REPO_OWNER = context.repo.owner;
+                    const REPO_NAME = context.repo.repo;
+
+                    // Fetch all comments on the pull request.
+                    const comments = await github.issues.listComments({
+                        owner: REPO_OWNER,
+                        repo: REPO_NAME,
+                        issue_number: PR_NUMBER,
+                    });
+
+                    console.log("COMMENTS_URL: https://api.github.com/repos/" + REPO_NAME + "/issues/" + PR_NUMBER + "/comments");
+
+                    for (const comment of comments.data) {
+                        console.log("COMMENT_OWNER: " + comment.user.login);
+
+                        // Identify the changeset comment by its heading.
+                        if (comment.body.includes("🦋 Changeset detected") || comment.body.includes("⚠️ No Changeset found") || comment.body.includes("❌ Invalid Changeset detected")) {
+                            console.log("COMMENT_ID_TO_DELETE: " + comment.id);
+
+                            // Remove the changeset comment using the comment ID.
+                            await github.issues.deleteComment({
+                                owner: REPO_OWNER,
+                                repo: REPO_NAME,
+                                comment_id: comment.id,
+                            });
+                        }
+                    }
+
+            - name: 💬 Add Changeset Comment
+              uses: actions/github-script@v3.1.0
+              with:
+                github-token: ${{ env.GH_TOKEN }}
+                script: |
+                    const fs = require('fs');
+                    const PR_NUMBER = Number(fs.readFileSync('./PR_NUMBER', 'utf8').trim());
+                    const REPO_OWNER = context.repo.owner;
+                    const REPO_NAME = context.repo.repo;
+                    const IS_RELEASE_MODE = process.env.IS_RELEASE_MODE === 'true';
+
+                    const files = await github.pulls.listFiles({
+                        owner: REPO_OWNER,
+                        repo: REPO_NAME,
+                        pull_number: PR_NUMBER,
+                    });
+
+                    const CHANGED_FILES = files.data.map(file => file.filename);
+                    console.log("CHANGED_FILES_URL: https://api.github.com/repos/" + REPO_NAME + "/pulls/" + PR_NUMBER + "/files");
+                    console.log("CHANGED_FILES:", CHANGED_FILES);
+
+                    const CHANGESET_FILES = CHANGED_FILES.filter(filename => /^\.changeset\/.*\.md$/.test(filename));
+                    const CHANGES_COUNT = CHANGESET_FILES.length;
+                    console.log("CHANGES_COUNT:", CHANGES_COUNT);
+                    console.log("IS_RELEASE_MODE:", IS_RELEASE_MODE);
+
+                    let invalidChangesets = [];
+
+                    // Check for major/minor changesets in release mode (master branch)
+                    if (IS_RELEASE_MODE && CHANGES_COUNT > 0) {
+                        for (const changesetFile of CHANGESET_FILES) {
+                            try {
+                                const fileResponse = await github.repos.getContent({
+                                    owner: REPO_OWNER,
+                                    repo: REPO_NAME,
+                                    path: changesetFile,
+                                    ref: `refs/pull/${PR_NUMBER}/head`
+                                });
+
+                                const content = Buffer.from(fileResponse.data.content, 'base64').toString('utf8');
+                                console.log("CHANGESET_CONTENT:", changesetFile, content);
+
+                                // Parse changeset frontmatter to check for major/minor releases
+                                const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+                                if (frontmatterMatch) {
+                                    const frontmatter = frontmatterMatch[1];
+                                    if (frontmatter.includes(': major') || frontmatter.includes(': minor')) {
+                                        invalidChangesets.push({
+                                            file: changesetFile,
+                                            type: frontmatter.includes(': major') ? 'major' : 'minor'
+                                        });
+                                    }
+                                }
+                            } catch (error) {
+                                console.log("Error reading changeset file:", changesetFile, error.message);
+                            }
+                        }
+                    }
+
+                    let COMMENT;
+                    if (CHANGES_COUNT > 0) {
+                        if (IS_RELEASE_MODE && invalidChangesets.length > 0) {
+                            console.log("Invalid changesets detected in release mode:", invalidChangesets);
+                            const invalidFiles = invalidChangesets.map(cs => `- \`${cs.file}\` (${cs.type})`).join('\n');
+                            COMMENT = `<h3>❌ Invalid Changeset detected</h3><p><b>🚀 WSO2 Identity Server release mode is currently activated!</b></p><p>The following changesets contain major/minor versions, but the master branch only allows patch releases:</p>\n${invalidFiles}\n<p><b>📋 Action Required:</b></p><ul><li>🔧 Update these changesets to use patch versions only, OR</li><li>🎯 Target the <code>next</code> branch for minor/major releases</li></ul><p>📚 Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn about our release strategy.</p>`;
+                        } else {
+                            console.log("Changeset detected");
+                            COMMENT = `<h3>🦋 Changeset detected</h3><p><b>The changes in this PR will be included in the next version bump.</b></p><p>Not sure what this means? <a href="https://github.com/changesets/changesets/blob/master/docs/adding-a-changeset.md">Click here to learn what changesets are</a>.</p>`;
+                        }
+                    } else {
+                        console.log("No changeset detected");
+                        COMMENT = `<h3>⚠️ No Changeset found</h3>Merging this PR will not cause a version bump for any packages. If these changes should not result in a new version, you're good to go.</p><p><b>If these changes should result in a version bump, you need to add a changeset.</b></p><p>Refer <a href="https://github.com/wso2/identity-apps/blob/master/docs/release/README.md">Release Documentation</a> to learn how to add a changeset.`;
+                    }
+
+                    await github.issues.createComment({
+                        owner: REPO_OWNER,
+                        repo: REPO_NAME,
+                        issue_number: PR_NUMBER,
+                        body: COMMENT,
+                    });

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -1,0 +1,46 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# --------------------------------------------------------------------------------------
+
+# This workflow will receive a PR and save the PR number for later use.
+
+name: 📩 Receive PR
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    save-pr-information:
+        runs-on: ubuntu-latest
+        steps:
+            - name: ⬇️ Checkout
+              uses: actions/checkout@v4
+
+            - name: ℹ️ Display PR Information
+              run: echo "PR Number \#${{github.event.number}}"
+
+            - name: 💾 Save PR Number for Later Use
+              run: echo "${{github.event.number}}" > PR_NUMBER
+
+            - name: 📦 Upload PR Number as Artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: pr-number
+                path: PR_NUMBER


### PR DESCRIPTION
### Purpose
This pull request introduces two new GitHub Actions workflows to automate the handling of pull requests and changeset checks. The workflows help ensure that each PR is properly tracked and validated for changesets, improving the release management process and compliance with versioning policies.

**New GitHub Actions Workflows**

* Added `.github/workflows/receive-pr.yml` to save the pull request number as an artifact when a PR is opened against the `main` branch, making it available for subsequent workflows.

**Automated Changeset Validation**

* Added `.github/workflows/check-changeset.yml` to automatically check for the presence and validity of changesets in PRs after the "Receive PR" workflow completes successfully.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
