### PR TITLE
chore(i18n): add Sinhala (si-LK) language support

### DIFF
--- a/packages/i18n/src/translations/index.ts
+++ b/packages/i18n/src/translations/index.ts
@@ -18,3 +18,4 @@
 
 export {default as en_US} from './en-US';
 export {default as hi_IN} from './hi-IN';
+export {default as si_LK} from './si-LK';

--- a/packages/i18n/src/translations/si-LK.ts
+++ b/packages/i18n/src/translations/si-LK.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable sort-keys */
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import {I18nTranslations, I18nMetadata, I18nBundle} from '../models/i18n';
+
+const translations: I18nTranslations = {
+  /* |---------------------------------------------------------------| */
+  /* |                        Elements                               | */
+  /* |---------------------------------------------------------------| */
+
+  /* Buttons */
+  'elements.buttons.signIn': 'ලොග් වෙන්න',
+  'elements.buttons.signOut': 'ඉවත් වෙන්න',
+  'elements.buttons.signUp': 'ලියාපදිංචි වෙන්න',
+  'elements.buttons.facebook': 'Facebook සමග ඉදිරියට යන්න',
+  'elements.buttons.google': 'Google සමග ඉදිරියට යන්න',
+  'elements.buttons.github': 'GitHub සමග ඉදිරියට යන්න',
+  'elements.buttons.microsoft': 'Microsoft සමග ඉදිරියට යන්න',
+  'elements.buttons.linkedin': 'LinkedIn සමග ඉදිරියට යන්න',
+  'elements.buttons.ethereum': 'Ethereum සමග ඉදිරියට යන්න',
+  'elements.buttons.multi.option': '{connection} සමග ඉදිරියට යන්න',
+  'elements.buttons.social': '{connection} සමග ඉදිරියට යන්න',
+
+  /* Fields */
+  'elements.fields.placeholder': 'ඔබේ {field} ඇතුලත් කරන්න',
+
+  /* |---------------------------------------------------------------| */
+  /* |                        Widgets                                | */
+  /* |---------------------------------------------------------------| */
+
+  /* Base Sign In */
+  'signin.title': 'ලොග් වෙන්න',
+  'signin.subtitle': 'ඉදිරියට යාමට ඔබේ සත්‍යාපන තොරතුරු ඇතුළත් කරන්න.',
+
+  /* Base Sign Up */
+  'signup.title': 'ලියාපදිංචි වන්න',
+  'signup.subtitle': 'ආරම්භ කිරීමට නව ගිණුමක් සාදන්න.',
+
+  /* Email OTP */
+  'email.otp.title': 'OTP සත්‍යාපනය',
+  'email.otp.subtitle': 'ඔබේ විද්‍යුත් තැපැල් ලිපිනයට යවන ලද කේතය ඇතුළත් කරන්න.',
+  'email.otp.submit.button': 'ඉදිරියට යන්න',
+
+  /* Identifier First */
+  'identifier.first.title': 'ලොග් වෙන්න',
+  'identifier.first.subtitle': 'ඔබේ පරිශීලක නාමය හෝ විද්‍යුත් තැපැල් ලිපිනය ඇතුළත් කරන්න.',
+  'identifier.first.submit.button': 'ඉදිරියට යන්න',
+
+  /* SMS OTP */
+  'sms.otp.title': 'OTP සත්‍යාපනය',
+  'sms.otp.subtitle': 'ඔබේ දුරකථන අංකයට යවන ලද කේතය ඇතුළත් කරන්න.',
+  'sms.otp.submit.button': 'ඉදිරියට යන්න',
+
+  /* TOTP */
+  'totp.title': 'ඔබගේ අනන්‍යතාවය තහවුරු කරන්න',
+  'totp.subtitle': 'ඔබේ authenticator යෙදුමෙන් ලබාගත් කේතය ඇතුළත් කරන්න.',
+  'totp.submit.button': 'ඉදිරියට යන්න',
+
+  /* Username Password */
+  'username.password.submit.button': 'ඉදිරියට යන්න',
+  'username.password.title': 'ලොග් වෙන්න',
+  'username.password.subtitle': 'ඉදිරියට යාමට ඔබේ පරිශීලක නාමය සහ මුරපදය ඇතුළත් කරන්න.',
+
+  /* |---------------------------------------------------------------| */
+  /* |                          User Profile                         | */
+  /* |---------------------------------------------------------------| */
+
+  'user.profile.title': 'පැතිකඩ',
+  'user.profile.update.generic.error': 'ඔබේ පැතිකඩ යාවත්කාලීන කිරීමේදී දෝෂයක් ඇතිවිය.කරුණාකර නැවත උත්සාහ කරන්න',
+
+  /* |---------------------------------------------------------------| */
+  /* |                     Organization Switcher                     | */
+  /* |---------------------------------------------------------------| */
+
+  'organization.switcher.select.organization': 'සංවිධානය තෝරන්න',
+  'organization.switcher.switch.organization': 'සංවිධානය මාරු කරන්න',
+  'organization.switcher.loading.organizations': 'සංවිධාන ලෝඩ් වෙමින්...',
+  'organization.switcher.members': 'සාමාජිකයන්',
+  'organization.switcher.member': 'සාමාජිකයා',
+  'organization.switcher.create.organization': 'සංවිධානයක් සාදන්න',
+  'organization.switcher.manage.organizations': 'සංවිධාන කළමනාකරණය කරන්න',
+  'organization.switcher.manage.button': 'කළමනාකරණය කරන්න',
+  'organization.switcher.organizations.title': 'සංවිධාන',
+  'organization.switcher.switch.button': 'මාරු කරන්න',
+  'organization.switcher.no.access': 'ප්‍රවේශය නැත',
+  'organization.switcher.status.label': 'තත්ත්වය:',
+  'organization.switcher.showing.count': 'මුළු සංවිධාන {showing} න් {total} ක් පෙන්වමින්',
+  'organization.switcher.refresh.button': 'නැවුම් කරන්න',
+  'organization.switcher.load.more': 'තවත් සංවිධාන ලෝඩ් කරන්න',
+  'organization.switcher.loading.more': 'ලෝඩ් වෙමින්...',
+  'organization.switcher.no.organizations': 'සංවිධාන කිසිවක් හමු නොවීය.',
+  'organization.switcher.error.prefix': 'දෝෂය:',
+  'organization.profile.title': 'සංවිධානයේ පැතිකඩ',
+  'organization.profile.loading': 'සංවිධානය ලෝඩ් වෙමින්...',
+  'organization.profile.error': 'සංවිධානය ලෝඩ් කිරීමට අසමත් විය',
+
+  'organization.create.title': 'සංවිධානය සාදන්න',
+  'organization.create.name.label': 'සංවිධානයේ නම',
+  'organization.create.name.placeholder': 'සංවිධානයේ නම ඇතුළත් කරන්න',
+  'organization.create.handle.label': 'සංවිධානයේ හෑන්ඩලය',
+  'organization.create.handle.placeholder': 'my-organization',
+  'organization.create.description.label': 'විස්තරය',
+  'organization.create.description.placeholder': 'සංවිධානයේ විස්තරය ඇතුළත් කරන්න',
+  'organization.create.button': 'සංවිධානය සාදන්න',
+  'organization.create.creating': 'සාදමින්...',
+  'organization.create.cancel': 'අවලංගු කරන්න',
+
+  /* |---------------------------------------------------------------| */
+  /* |                        Messages                               | */
+  /* |---------------------------------------------------------------| */
+
+  'messages.loading': 'ලෝඩ් වෙමින්...',
+
+  /* |---------------------------------------------------------------| */
+  /* |                        Errors                                 | */
+  /* |---------------------------------------------------------------| */
+
+  'errors.title': 'දෝෂය',
+  'errors.sign.in.initialization': 'ආරම්භ කිරීමේදී දෝෂයක් සිදු විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න.',
+  'errors.sign.in.flow.failure': 'ලොග් වීමේදී දෝෂයක් සිදු විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න.',
+  'errors.sign.in.flow.completion.failure':
+    'ලොග් වීමේ ක්‍රියාවලිය සම්පූර්ණ කිරීමේදී දෝෂයක් සිදු විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න.',
+  'errors.sign.in.flow.passkeys.failure': 'passkeys සමඟ ලොග් වීමේදී දෝෂයක් සිදු විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න.',
+  'errors.sign.in.flow.passkeys.completion.failure':
+    'passkeys සමඟ ලොග් වීමේ ක්‍රියාවලිය සම්පූර්ණ කිරීමේදී දෝෂයක් සිදු විය. කරුණාකර පසුව නැවත උත්සාහ කරන්න.',
+};
+
+const metadata: I18nMetadata = {
+  localeCode: 'si_LK',
+  countryCode: 'LK',
+  languageCode: 'si',
+  displayName: 'සිංහල (ශ්‍රී ලංකාව)',
+  direction: 'ltr',
+};
+
+const si_LK: I18nBundle = {
+  metadata,
+  translations,
+};
+
+export default si_LK;


### PR DESCRIPTION
### Purpose
Added Sinhala (`si-LK`) language support to the `@asgardeo/i18n` package.
This resolves the current limitation where Sinhala-speaking users could not view translated UI components, significantly improving localization and accessibility for Sri Lankan users.

No UI or functional changes introduced — only language resource additions for i18n.

### Related Issues
- Fixes #155

### Related PRs
- N/A

### Checklist
- [x] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
