### PR TITLE
fix(nextjs): complete embedded sign-up cleanly, auto sign-in, honour afterSignInUrl, add http client

### DIFF
--- a/.changeset/fix-signup-completion-crash.md
+++ b/.changeset/fix-signup-completion-crash.md
@@ -1,0 +1,20 @@
+---
+'@asgardeo/react': patch
+'@asgardeo/nextjs': patch
+'@asgardeo/i18n': patch
+'@asgardeo/javascript': patch
+---
+
+Fix `<SignUp />` crashing with `Cannot read properties of undefined (reading 'flowStatus')` right after a successful registration in Next.js. The sign-up server action now returns the completed flow response along with `afterSignUpUrl`, the client provider hands it back to the component instead of `undefined`, and the embedded sign-up components guard against an empty response. Once registration completes, the form is replaced by a success message instead of lingering with the filled-in fields. Server-side validation failures returned with an incomplete registration flow (for example, a password that does not meet the policy) are now shown in the form, and the sign-up and recovery renderers no longer trigger React `key` warnings.
+
+Add a dedicated `afterSignUpUrl` setting (`NEXT_PUBLIC_ASGARDEO_AFTER_SIGN_UP_URL` in Next.js) for where to land after a successful embedded sign-up, falling back to `afterSignInUrl`; the `afterSignUpUrl` prop of the Next.js `<SignUp />` component now overrides it per form instead of being ignored. Fix `createRouteMatcher` so wildcard patterns such as `/dashboard(.*)` match as documented.
+
+Show the actual server error in the embedded sign-in and sign-up components instead of a generic "An error occurred while initializing" message, including errors that crossed a Next.js server action boundary (for example, "App native authentication is not enabled for the application").
+
+Next.js: the `afterSignInUrl` and `afterSignOutUrl` props of `<AsgardeoProvider>` are now applied to the client configuration (they were previously dropped, so sign-in always redirected to the app origin), relative values such as `"/dashboard"` are resolved against the app origin before being used as OAuth redirect URIs, and `afterSignInUrl` is exposed through `useAsgardeo()`. Add `useAsgardeo().http.request` / `http.requestAll` for authenticated calls from Client Components, backed by a server action that attaches the session's access token on the server and only allows requests to the identity server or the app's own origin. When the SCIM2 profile cannot be loaded, the SDK now logs a warning explaining the fallback to ID token claims (and hints at the missing `internal_login` scope) instead of failing silently.
+
+React: `<UserProfile />` now recognises the camelCase mutability values (`readWrite`, `readOnly`) returned by SCIM2 schemas, so empty editable attributes are offered for editing and read-only ones are not.
+
+Next.js: after a successful embedded sign-up the SDK now signs the new user in automatically with the credentials they just submitted (via the app-native sign-in flow) and sets the session cookie, so `<SignUp />` lands the user inside the app instead of on a login page. When an automatic sign-in is not possible (app-native authentication disabled, MFA, multi-step registration) the user is sent to `afterSignUpUrl` without a session and a warning explains why.
+
+Resolve the OIDC provider metadata on demand when building the sign-out URL, so signing out after an app-native sign-in (or on a fresh server instance) no longer fails with "Sign-out endpoint not found".

--- a/packages/i18n/src/models/i18n.ts
+++ b/packages/i18n/src/models/i18n.ts
@@ -77,6 +77,7 @@ export interface I18nTranslations {
   /* Base Sign Up */
   'signup.heading': string;
   'signup.subheading': string;
+  'signup.success': string;
 
   /* Email OTP */
   'email.otp.heading': string;

--- a/packages/i18n/src/translations/en-US.ts
+++ b/packages/i18n/src/translations/en-US.ts
@@ -80,6 +80,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'Sign Up',
   'signup.subheading': 'Create a new account to get started.',
+  'signup.success': 'Your account has been created successfully.',
 
   /* Email OTP */
   'email.otp.heading': 'OTP Verification',

--- a/packages/i18n/src/translations/fr-FR.ts
+++ b/packages/i18n/src/translations/fr-FR.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': "S'inscrire",
   'signup.subheading': 'Créez un nouveau compte pour commencer.',
+  'signup.success': 'Votre compte a été créé avec succès.',
 
   /* Email OTP */
   'email.otp.heading': 'Vérification OTP',

--- a/packages/i18n/src/translations/hi-IN.ts
+++ b/packages/i18n/src/translations/hi-IN.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'साइन अप',
   'signup.subheading': 'शुरू करने के लिए नया खाता बनाएं।',
+  'signup.success': 'आपका खाता सफलतापूर्वक बना दिया गया है।',
 
   /* Email OTP */
   'email.otp.heading': 'OTP सत्यापन',

--- a/packages/i18n/src/translations/ja-JP.ts
+++ b/packages/i18n/src/translations/ja-JP.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'サインアップ',
   'signup.subheading': 'はじめるには新しいアカウントを作成してください。',
+  'signup.success': 'アカウントが正常に作成されました。',
 
   /* Email OTP */
   'email.otp.heading': 'OTP認証',

--- a/packages/i18n/src/translations/pt-BR.ts
+++ b/packages/i18n/src/translations/pt-BR.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'Cadastra-se',
   'signup.subheading': 'Crie uma nova conta para iniciar.',
+  'signup.success': 'Sua conta foi criada com sucesso.',
 
   /* Email OTP */
   'email.otp.heading': 'Verificação OTP',

--- a/packages/i18n/src/translations/pt-PT.ts
+++ b/packages/i18n/src/translations/pt-PT.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'Registar-se',
   'signup.subheading': 'Crie uma nova conta para começar.',
+  'signup.success': 'A sua conta foi criada com sucesso.',
 
   /* Email OTP */
   'email.otp.heading': 'Verificação OTP',

--- a/packages/i18n/src/translations/si-LK.ts
+++ b/packages/i18n/src/translations/si-LK.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'ලියාපදිංචි වන්න',
   'signup.subheading': 'ආරම්භ කිරීමට නව ගිණුමක් සාදන්න.',
+  'signup.success': 'ඔබගේ ගිණුම සාර්ථකව සාදන ලදී.',
 
   /* Email OTP */
   'email.otp.heading': 'OTP සත්‍යාපනය',

--- a/packages/i18n/src/translations/ta-IN.ts
+++ b/packages/i18n/src/translations/ta-IN.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'பதிவு செய்',
   'signup.subheading': 'தொடங்க புதிய கணக்கை உருவாக்கவும்.',
+  'signup.success': 'உங்கள் கணக்கு வெற்றிகரமாக உருவாக்கப்பட்டது.',
 
   /* Email OTP */
   'email.otp.heading': 'OTP சரிபார்ப்பு',

--- a/packages/i18n/src/translations/te-IN.ts
+++ b/packages/i18n/src/translations/te-IN.ts
@@ -78,6 +78,7 @@ const translations: I18nTranslations = {
   /* Base Sign Up */
   'signup.heading': 'సైన్ అప్ చేయండి',
   'signup.subheading': 'కొత్త అకౌంట్ సృష్టించండి.',
+  'signup.success': 'మీ ఖాతా విజయవంతంగా సృష్టించబడింది.',
 
   /* Email OTP */
   'email.otp.heading': 'OTP వెరిఫికేషన్',

--- a/packages/javascript/src/__legacy__/client.ts
+++ b/packages/javascript/src/__legacy__/client.ts
@@ -541,7 +541,15 @@ export class AsgardeoAuthClient<T> {
    * @preserve
    */
   public async getSignOutUrl(userId?: string): Promise<string> {
-    const logoutEndpoint: string | undefined = (await this.oidcProviderMetaDataProvider())?.end_session_endpoint;
+    let logoutEndpoint: string | undefined = (await this.oidcProviderMetaDataProvider())?.end_session_endpoint;
+
+    if (!logoutEndpoint) {
+      // The provider metadata may not have been resolved yet in this process (e.g. a fresh server
+      // instance, or an app-native sign-in that never built an authorize URL). Resolve it on demand.
+      await this.loadOpenIDProviderConfiguration(false);
+      logoutEndpoint = (await this.oidcProviderMetaDataProvider())?.end_session_endpoint;
+    }
+
     const configData: StrictAuthClientConfig = await this.configProvider();
 
     if (!logoutEndpoint || logoutEndpoint.trim().length === 0) {

--- a/packages/javascript/src/models/config.ts
+++ b/packages/javascript/src/models/config.ts
@@ -69,6 +69,15 @@ export interface BaseConfig<T = unknown> extends WithPreferences, WithExtensions
   afterSignInUrl?: string | undefined;
 
   /**
+   * Optional URL to navigate to after a successful embedded sign-up.
+   * Falls back to `afterSignInUrl` when not provided.
+   *
+   * @example
+   * "/welcome" or "https://your-app.com/welcome"
+   */
+  afterSignUpUrl?: string | undefined;
+
+  /**
    * Optional URL where the authorization server should redirect after sign out.
    * This must match one of the allowed post logout redirect URIs configured in your IdP
    * and is used to redirect the user after they have signed out.

--- a/packages/nextjs/src/AsgardeoNextClient.ts
+++ b/packages/nextjs/src/AsgardeoNextClient.ts
@@ -61,6 +61,7 @@ import {AsgardeoNextConfig} from './models/config';
 import getClientOrigin from './server/actions/getClientOrigin';
 import getSessionId from './server/actions/getSessionId';
 import decorateConfigWithNextEnv from './utils/decorateConfigWithNextEnv';
+import logger from './utils/logger';
 
 /**
  * Client for mplementing Asgardeo in Next.js applications.
@@ -118,6 +119,7 @@ class AsgardeoNextClient<T extends AsgardeoNextConfig = AsgardeoNextConfig> exte
       signInUrl,
       afterSignInUrl,
       afterSignOutUrl,
+      afterSignUpUrl,
       signUpUrl,
       ...rest
     } = decorateConfigWithNextEnv(config);
@@ -132,10 +134,29 @@ class AsgardeoNextClient<T extends AsgardeoNextConfig = AsgardeoNextConfig> exte
 
     const origin: string = await getClientOrigin();
 
+    /**
+     * `afterSignInUrl` / `afterSignOutUrl` are sent to the identity server as OAuth redirect URIs, so a
+     * relative value such as "/dashboard" has to be resolved against the app origin first.
+     */
+    const resolveAgainstOrigin = (url: string | undefined): string | undefined => {
+      if (!url) {
+        return undefined;
+      }
+
+      try {
+        return new URL(url, origin).toString();
+      } catch {
+        return url;
+      }
+    };
+
+    const resolvedAfterSignInUrl: string = resolveAgainstOrigin(afterSignInUrl) ?? origin;
+
     return this.asgardeo.initialize(
       {
-        afterSignInUrl: afterSignInUrl ?? origin,
-        afterSignOutUrl: afterSignOutUrl ?? origin,
+        afterSignInUrl: resolvedAfterSignInUrl,
+        afterSignOutUrl: resolveAgainstOrigin(afterSignOutUrl) ?? origin,
+        afterSignUpUrl: afterSignUpUrl ?? resolvedAfterSignInUrl,
         baseUrl,
         clientId,
         clientSecret,
@@ -227,6 +248,18 @@ class AsgardeoNextClient<T extends AsgardeoNextConfig = AsgardeoNextConfig> exte
 
       return output;
     } catch (error) {
+      const statusCode: number | undefined = (error as {statusCode?: number})?.statusCode;
+      const scopeHint: string =
+        statusCode === 401 || statusCode === 403
+          ? ' The request was rejected; make sure the `internal_login` scope is included in `scopes` (it is required by the SCIM2 /Me endpoint).'
+          : '';
+
+      logger.warn(
+        `[AsgardeoNextClient] Could not load the user profile from SCIM2, falling back to the ID token claims. ` +
+          `Only attributes shared with the application will be shown and profile editing is disabled.${scopeHint} ` +
+          `Reason: ${error instanceof Error ? error.message : String(error)}`,
+      );
+
       return {
         flattenedProfile: extractUserClaimsFromIdToken(await this.asgardeo.getDecodedIdToken(userId)),
         profile: extractUserClaimsFromIdToken(await this.asgardeo.getDecodedIdToken(userId)),

--- a/packages/nextjs/src/client/components/presentation/SignUp/SignUp.tsx
+++ b/packages/nextjs/src/client/components/presentation/SignUp/SignUp.tsx
@@ -105,7 +105,7 @@ const SignUp: FC<SignUpProps> = ({
       );
     }
 
-    return (await signUp(payload)) as unknown as Promise<EmbeddedFlowExecuteResponse>;
+    return (await signUp(payload, undefined, {afterSignUpUrl})) as unknown as Promise<EmbeddedFlowExecuteResponse>;
   };
 
   return (

--- a/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -32,6 +32,9 @@ import {
   TokenResponse,
   CreateOrganizationPayload,
   AsgardeoRuntimeError,
+  EmbeddedFlowStatus,
+  HttpRequestConfig,
+  HttpResponse,
 } from '@asgardeo/node';
 import {
   I18nProvider,
@@ -48,6 +51,7 @@ import {AppRouterInstance} from 'next/dist/shared/lib/app-router-context.shared-
 import {useRouter, useSearchParams} from 'next/navigation';
 import {FC, PropsWithChildren, RefObject, useEffect, useMemo, useRef, useState} from 'react';
 import AsgardeoContext, {AsgardeoContextProps} from './AsgardeoContext';
+import {HttpRequestActionResult} from '../../../server/actions/httpRequestAction';
 import {RefreshResult} from '../../../server/actions/refreshToken';
 import logger from '../../../utils/logger';
 
@@ -56,6 +60,7 @@ import logger from '../../../utils/logger';
  */
 export type AsgardeoClientProviderProps = Partial<Omit<AsgardeoProviderProps, 'baseUrl' | 'clientId'>> &
   Pick<AsgardeoProviderProps, 'baseUrl' | 'clientId'> & {
+    afterSignInUrl?: string;
     applicationId: AsgardeoContextProps['applicationId'];
     brandingPreference?: BrandingPreference | null;
     clearSession: () => Promise<void>;
@@ -67,6 +72,7 @@ export type AsgardeoClientProviderProps = Partial<Omit<AsgardeoProviderProps, 'b
       state: string,
       sessionState?: string,
     ) => Promise<{error?: string; redirectUrl?: string; success: boolean}>;
+    httpRequest?: (requestConfig: HttpRequestConfig) => Promise<HttpRequestActionResult>;
     isSignedIn: boolean;
     myOrganizations: Organization[];
     organizationHandle: AsgardeoContextProps['organizationHandle'];
@@ -109,6 +115,8 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
   getAllOrganizations,
   switchOrganization,
   brandingPreference,
+  afterSignInUrl,
+  httpRequest,
 }: PropsWithChildren<AsgardeoClientProviderProps>) => {
   const reRenderCheckRef: RefObject<boolean> = useRef(false);
   const router: AppRouterInstance = useRouter();
@@ -229,6 +237,7 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
   const handleSignUp = async (
     payload: EmbeddedFlowExecuteRequestPayload,
     request: EmbeddedFlowExecuteRequestConfig,
+    options?: {afterSignUpUrl?: string},
   ): Promise<any> => {
     if (!signUp) {
       throw new AsgardeoRuntimeError(
@@ -249,9 +258,19 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
 
     // After the Embedded flow is successful, the URL to navigate next is sent as `afterSignUpUrl` in the response.
     if (result?.data?.afterSignUpUrl) {
-      router.push(result.data.afterSignUpUrl);
+      const {afterSignUpUrl, signedIn, ...flowResponse}: any = result.data;
 
-      return undefined;
+      // A URL passed by the caller (e.g. the `afterSignUpUrl` prop of `<SignUp />`) wins over the configured one.
+      router.push(options?.afterSignUpUrl || afterSignUpUrl);
+
+      if (signedIn) {
+        // A session cookie was set during sign-up; re-render server components so the signed-in state is picked up.
+        router.refresh();
+      }
+
+      // Hand the completed flow back to the caller (e.g. `<SignUp />`) so it can finish its lifecycle
+      // while the navigation is in flight, instead of receiving `undefined` and crashing.
+      return {...flowResponse, flowStatus: flowResponse.flowStatus ?? EmbeddedFlowStatus.Complete};
     }
 
     if (result?.error) {
@@ -293,11 +312,45 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
     }
   };
 
+  /**
+   * Performs an authenticated HTTP request through a server action so the access token stays on the server.
+   * Mirrors `http.request` of the React SDK: resolves with the response, rejects with an `Error` carrying `response`.
+   */
+  const handleHttpRequest = async (requestConfig?: HttpRequestConfig): Promise<HttpResponse> => {
+    if (!httpRequest) {
+      throw new AsgardeoRuntimeError(
+        '`http.request` is not available. Make sure the component is rendered inside `<AsgardeoProvider>`.',
+        'AsgardeoClientProvider-handleHttpRequest-RuntimeError-001',
+        'nextjs',
+      );
+    }
+
+    const result: HttpRequestActionResult = await httpRequest(requestConfig ?? {});
+
+    if (!result.success) {
+      const error: Error & {response?: HttpResponse} = new Error(result.error ?? 'HTTP request failed.');
+
+      error.response = result.data;
+
+      throw error;
+    }
+
+    return result.data as HttpResponse;
+  };
+
+  const handleHttpRequestAll = async (requestConfigs?: HttpRequestConfig[]): Promise<HttpResponse[]> =>
+    Promise.all((requestConfigs ?? []).map((requestConfig: HttpRequestConfig) => handleHttpRequest(requestConfig)));
+
   const contextValue: AsgardeoContextProps = useMemo(
     () => ({
+      afterSignInUrl,
       applicationId,
       baseUrl,
       clearSession,
+      http: {
+        request: handleHttpRequest,
+        requestAll: handleHttpRequestAll,
+      },
       isLoading,
       isSignedIn,
       organizationHandle,
@@ -309,7 +362,18 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
       signUpUrl,
       user,
     }),
-    [baseUrl, user, isSignedIn, isLoading, signInUrl, signUpUrl, applicationId, organizationHandle],
+    [
+      baseUrl,
+      user,
+      isSignedIn,
+      isLoading,
+      signInUrl,
+      signUpUrl,
+      applicationId,
+      organizationHandle,
+      afterSignInUrl,
+      httpRequest,
+    ],
   );
 
   const handleProfileUpdate = (payload: User): void => {

--- a/packages/nextjs/src/server/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/server/AsgardeoProvider.tsx
@@ -32,6 +32,7 @@ import getSessionPayload from './actions/getSessionPayload';
 import getUserAction from './actions/getUserAction';
 import getUserProfileAction from './actions/getUserProfileAction';
 import handleOAuthCallbackAction from './actions/handleOAuthCallbackAction';
+import httpRequestAction from './actions/httpRequestAction';
 import isSignedIn from './actions/isSignedIn';
 import refreshToken from './actions/refreshToken';
 import signInAction from './actions/signInAction';
@@ -84,8 +85,6 @@ export type AsgardeoServerProviderProps = Partial<AsgardeoProviderProps> & {
  */
 const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>> = async ({
   children,
-  afterSignInUrl,
-  afterSignOutUrl,
   ..._config
 }: PropsWithChildren<AsgardeoServerProviderProps>): Promise<ReactElement> => {
   const asgardeoClient: AsgardeoNextClient = AsgardeoNextClient.getInstance();
@@ -226,6 +225,8 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
       handleOAuthCallback={handleOAuthCallbackAction}
       signInUrl={config?.signInUrl}
       signUpUrl={config?.signUpUrl}
+      afterSignInUrl={config?.afterSignInUrl}
+      httpRequest={httpRequestAction}
       preferences={config?.preferences}
       clientId={config?.clientId}
       user={user}

--- a/packages/nextjs/src/server/actions/__tests__/httpRequestAction.test.ts
+++ b/packages/nextjs/src/server/actions/__tests__/httpRequestAction.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi, Mock} from 'vitest';
+import getAccessToken from '../getAccessToken';
+import httpRequestAction, {HttpRequestActionResult} from '../httpRequestAction';
+
+vi.mock('../getAccessToken', () => ({default: vi.fn()}));
+vi.mock('../getClientOrigin', () => ({default: vi.fn().mockResolvedValue('http://localhost:3000')}));
+vi.mock('../../../AsgardeoNextClient', () => ({
+  default: {
+    getInstance: (): {getConfiguration: Mock} => ({
+      getConfiguration: vi.fn().mockResolvedValue({baseUrl: 'https://api.asgardeo.io/t/acme'}),
+    }),
+  },
+}));
+
+const jsonResponse = (body: unknown, status: number = 200): Response =>
+  new Response(JSON.stringify(body), {headers: {'content-type': 'application/json'}, status});
+
+describe('httpRequestAction', () => {
+  beforeEach(() => {
+    (getAccessToken as Mock).mockResolvedValue('token-123');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({userName: 'jane'})));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('attaches the session access token and returns the parsed response', async () => {
+    const result: HttpRequestActionResult = await httpRequestAction({url: 'https://api.asgardeo.io/t/acme/scim2/Me'});
+
+    expect(result.success).toBe(true);
+    expect(result.data?.status).toBe(200);
+    expect(result.data?.data).toEqual({userName: 'jane'});
+
+    const [, init] = (fetch as Mock).mock.calls[0];
+    expect(init.headers.Authorization).toBe('Bearer token-123');
+  });
+
+  it('allows the app origin and appends query params', async () => {
+    await httpRequestAction({params: {page: 2}, url: 'http://localhost:3000/api/items'});
+
+    expect((fetch as Mock).mock.calls[0][0]).toBe('http://localhost:3000/api/items?page=2');
+  });
+
+  it('refuses origins other than the identity server and the app', async () => {
+    const result: HttpRequestActionResult = await httpRequestAction({url: 'http://169.254.169.254/latest/meta-data/'});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not allowed');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly without a session', async () => {
+    (getAccessToken as Mock).mockResolvedValue(undefined);
+
+    const result: HttpRequestActionResult = await httpRequestAction({url: 'https://api.asgardeo.io/t/acme/scim2/Me'});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('No active session');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('reports non-2xx responses as failures but keeps the body', async () => {
+    (fetch as Mock).mockResolvedValue(jsonResponse({detail: 'nope'}, 403));
+
+    const result: HttpRequestActionResult = await httpRequestAction({url: 'https://api.asgardeo.io/t/acme/scim2/Me'});
+
+    expect(result.success).toBe(false);
+    expect(result.data?.status).toBe(403);
+    expect(result.data?.data).toEqual({detail: 'nope'});
+  });
+});

--- a/packages/nextjs/src/server/actions/httpRequestAction.ts
+++ b/packages/nextjs/src/server/actions/httpRequestAction.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use server';
+
+import {HttpRequestConfig, HttpResponse} from '@asgardeo/node';
+import getAccessToken from './getAccessToken';
+import getClientOrigin from './getClientOrigin';
+import AsgardeoNextClient from '../../AsgardeoNextClient';
+
+/**
+ * Result of {@link httpRequestAction}. Kept serializable so it can cross the server action boundary.
+ */
+export interface HttpRequestActionResult {
+  data?: HttpResponse;
+  error?: string;
+  success: boolean;
+}
+
+/**
+ * Origins a request may target: the identity server (`baseUrl`) and the app's own origin.
+ * Anything else is refused so that a Client Component cannot turn the server into an open proxy
+ * (for example towards internal networks or cloud metadata endpoints).
+ */
+const getAllowedOrigins = async (): Promise<string[]> => {
+  const origins: string[] = [];
+
+  try {
+    const {baseUrl}: {baseUrl?: string} = await AsgardeoNextClient.getInstance().getConfiguration();
+
+    if (baseUrl) {
+      origins.push(new URL(baseUrl).origin);
+    }
+  } catch {
+    // Configuration not available; only the app origin will be allowed.
+  }
+
+  try {
+    origins.push(new URL(await getClientOrigin()).origin);
+  } catch {
+    // No request headers available (e.g. outside a request); skip the app origin.
+  }
+
+  return origins;
+};
+
+/**
+ * Server action that performs an HTTP request on behalf of the signed-in user.
+ *
+ * The access token never leaves the server: it is read from the session cookie and attached as a
+ * `Bearer` token unless `attachToken` is `false`. This backs `useAsgardeo().http.request` in Client Components.
+ * Only the identity server's origin and the app's own origin can be targeted.
+ *
+ * @param requestConfig - Request configuration (`url`, `method`, `headers`, `data`, `params`, `attachToken`).
+ * @returns The response (status, headers, parsed body) or an error description.
+ */
+const httpRequestAction = async (requestConfig: HttpRequestConfig): Promise<HttpRequestActionResult> => {
+  const {url, method = 'GET', headers = {}, data, params, attachToken = true} = requestConfig ?? {};
+
+  if (!url) {
+    return {error: '[httpRequestAction] `url` is required.', success: false};
+  }
+
+  const accessToken: string | undefined = attachToken ? await getAccessToken() : undefined;
+
+  if (attachToken && !accessToken) {
+    return {
+      error: '[httpRequestAction] No active session. Sign in before making authenticated requests.',
+      success: false,
+    };
+  }
+
+  let resolvedUrl: URL;
+
+  try {
+    resolvedUrl = new URL(url);
+  } catch {
+    return {error: `[httpRequestAction] Invalid \`url\`: ${url}`, success: false};
+  }
+
+  const allowedOrigins: string[] = await getAllowedOrigins();
+
+  if (!allowedOrigins.includes(resolvedUrl.origin)) {
+    return {
+      error: `[httpRequestAction] Requests to ${
+        resolvedUrl.origin
+      } are not allowed. Only the identity server and the app's own origin can be called (${
+        allowedOrigins.join(', ') || 'none resolved'
+      }).`,
+      success: false,
+    };
+  }
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]: [string, unknown]) => {
+      if (value !== undefined && value !== null) {
+        resolvedUrl.searchParams.set(key, String(value));
+      }
+    });
+  }
+
+  const isJsonBody: boolean = data !== undefined && typeof data !== 'string';
+  const requestHeaders: Record<string, string> = {
+    ...(isJsonBody ? {'Content-Type': 'application/json'} : {}),
+    ...headers,
+    ...(accessToken ? {Authorization: `Bearer ${accessToken}`} : {}),
+  };
+
+  let body: string | undefined;
+
+  if (data !== undefined) {
+    body = isJsonBody ? JSON.stringify(data) : (data as string);
+  }
+
+  try {
+    const response: Response = await fetch(resolvedUrl.toString(), {
+      body,
+      headers: requestHeaders,
+      method,
+    });
+
+    const rawBody: string = await response.text();
+    let parsedBody: unknown = rawBody;
+
+    try {
+      parsedBody = rawBody ? JSON.parse(rawBody) : undefined;
+    } catch {
+      // Not JSON, keep the raw text.
+    }
+
+    const responseHeaders: Record<string, string> = {};
+
+    response.headers.forEach((value: string, key: string) => {
+      responseHeaders[key] = value;
+    });
+
+    const httpResponse: HttpResponse = {
+      config: requestConfig,
+      data: parsedBody,
+      headers: responseHeaders,
+      status: response.status,
+      statusText: response.statusText,
+    };
+
+    if (!response.ok) {
+      return {
+        data: httpResponse,
+        error: `[httpRequestAction] Request to ${resolvedUrl.origin}${resolvedUrl.pathname} failed with status ${response.status}.`,
+        success: false,
+      };
+    }
+
+    return {data: httpResponse, success: true};
+  } catch (error) {
+    return {
+      error: `[httpRequestAction] ${error instanceof Error ? error.message : String(error)}`,
+      success: false,
+    };
+  }
+};
+
+export default httpRequestAction;

--- a/packages/nextjs/src/server/actions/signUpAction.ts
+++ b/packages/nextjs/src/server/actions/signUpAction.ts
@@ -20,6 +20,7 @@
 
 import {EmbeddedFlowExecuteRequestPayload, EmbeddedFlowExecuteResponse, EmbeddedFlowStatus} from '@asgardeo/node';
 import AsgardeoNextClient from '../../AsgardeoNextClient';
+import autoSignInAfterSignUp, {extractSignUpCredentials, SignUpCredentials} from '../../utils/autoSignInAfterSignUp';
 
 /**
  * Server action for signing in a user.
@@ -37,7 +38,7 @@ const signUpAction = async (
         afterSignUpUrl?: string;
         signUpUrl?: string;
       }
-    | EmbeddedFlowExecuteResponse;
+    | (EmbeddedFlowExecuteResponse & {afterSignUpUrl?: string; signedIn?: boolean});
   error?: string;
   success: boolean;
 }> => {
@@ -54,9 +55,21 @@ const signUpAction = async (
     const response: any = await client.signUp(payload);
 
     if (response.flowStatus === EmbeddedFlowStatus.Complete) {
-      const afterSignUpUrl: string = await (await client.getStorageManager()).getConfigDataParameter('afterSignInUrl');
+      const storageManager: Awaited<ReturnType<typeof client.getStorageManager>> = await client.getStorageManager();
+      const afterSignUpUrl: string = String(
+        (await storageManager.getConfigDataParameter('afterSignUpUrl')) ??
+          (await storageManager.getConfigDataParameter('afterSignInUrl')),
+      );
 
-      return {data: {afterSignUpUrl: String(afterSignUpUrl)}, success: true};
+      // Sign the new user in with the credentials they just submitted so they land inside the app.
+      // When that is not possible (MFA, app-native auth disabled, multi-step registration), they are
+      // sent to `afterSignUpUrl` without a session and can sign in manually.
+      const credentials: SignUpCredentials | undefined = extractSignUpCredentials(payload.inputs);
+      const signedIn: boolean = credentials ? await autoSignInAfterSignUp(credentials) : false;
+
+      // Return the completed flow response along with the URL so that client components
+      // (e.g. `<SignUp />`) can finish their own lifecycle instead of receiving nothing.
+      return {data: {...response, afterSignUpUrl: String(afterSignUpUrl), signedIn}, success: true};
     }
 
     return {data: response as EmbeddedFlowExecuteResponse, success: true};

--- a/packages/nextjs/src/server/middleware/createRouteMatcher.ts
+++ b/packages/nextjs/src/server/middleware/createRouteMatcher.ts
@@ -39,11 +39,16 @@ import {NextRequest} from 'next/server';
  */
 const createRouteMatcher = (patterns: string[]): ((req: NextRequest) => boolean) => {
   const regexPatterns: RegExp[] = patterns.map((pattern: string): RegExp => {
-    // Convert glob-like patterns to regex
+    // Convert glob-like patterns to regex.
+    // `(.*)` is a wildcard group and must be protected before dots and stars are rewritten,
+    // otherwise `/dashboard(.*)` becomes `^/dashboard(\\..*)$` and never matches `/dashboard`.
+    const WILDCARD_GROUP: string = '__WILDCARD_GROUP__';
     const regexPattern: string = pattern
+      .replace(/\(\.\*\)/g, WILDCARD_GROUP)
       .replace(/\./g, '\\.') // Escape dots
       .replace(/\*/g, '.*') // Convert * to .*
-      .replace(/\(\.\*\)/g, '(.*)'); // Handle explicit (.*) patterns
+      .split(WILDCARD_GROUP)
+      .join('(.*)');
 
     return new RegExp(`^${regexPattern}$`);
   });

--- a/packages/nextjs/src/utils/__tests__/autoSignInAfterSignUp.test.ts
+++ b/packages/nextjs/src/utils/__tests__/autoSignInAfterSignUp.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it, vi} from 'vitest';
+
+vi.mock('../../server/actions/signInAction', () => ({default: vi.fn()}));
+
+const {extractSignUpCredentials} = await import('../autoSignInAfterSignUp');
+
+describe('extractSignUpCredentials', () => {
+  it('returns undefined without inputs', () => {
+    expect(extractSignUpCredentials(undefined)).toBeUndefined();
+    expect(extractSignUpCredentials({})).toBeUndefined();
+  });
+
+  it('reads the WSO2 claim URIs used by the registration flow', () => {
+    expect(
+      extractSignUpCredentials({
+        'http://wso2.org/claims/emailaddress': 'jane@example.com',
+        'http://wso2.org/claims/username': 'jane',
+        password: 'Secret@123',
+      }),
+    ).toEqual({password: 'Secret@123', username: 'jane'});
+  });
+
+  it('falls back to the email address when there is no username input', () => {
+    expect(
+      extractSignUpCredentials({'http://wso2.org/claims/emailaddress': 'jane@example.com', password: 'Secret@123'}),
+    ).toEqual({password: 'Secret@123', username: 'jane@example.com'});
+  });
+
+  it('requires both a username and a password', () => {
+    expect(extractSignUpCredentials({'http://wso2.org/claims/username': 'jane'})).toBeUndefined();
+    expect(extractSignUpCredentials({password: 'Secret@123'})).toBeUndefined();
+    expect(extractSignUpCredentials({'http://wso2.org/claims/username': '', password: 'Secret@123'})).toBeUndefined();
+  });
+});

--- a/packages/nextjs/src/utils/autoSignInAfterSignUp.ts
+++ b/packages/nextjs/src/utils/autoSignInAfterSignUp.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {EmbeddedSignInFlowAuthenticator, EmbeddedSignInFlowInitiateResponse} from '@asgardeo/node';
+import logger from './logger';
+import signInAction from '../server/actions/signInAction';
+
+/**
+ * Input keys, in order of preference, under which the registration form submits the username.
+ */
+const USERNAME_INPUT_KEYS: string[] = [
+  'http://wso2.org/claims/username',
+  'username',
+  'userName',
+  'http://wso2.org/claims/emailaddress',
+  'email',
+];
+
+const PASSWORD_INPUT_KEYS: string[] = ['password', 'http://wso2.org/claims/password'];
+
+export interface SignUpCredentials {
+  password: string;
+  username: string;
+}
+
+/**
+ * Extracts the username and password from the inputs of a registration flow submission, if present.
+ */
+export const extractSignUpCredentials = (inputs?: Record<string, unknown>): SignUpCredentials | undefined => {
+  if (!inputs) {
+    return undefined;
+  }
+
+  const pick = (keys: string[]): string | undefined =>
+    keys.map((key: string) => inputs[key]).find((value: unknown) => typeof value === 'string' && value !== '') as
+      | string
+      | undefined;
+
+  const username: string | undefined = pick(USERNAME_INPUT_KEYS);
+  const password: string | undefined = pick(PASSWORD_INPUT_KEYS);
+
+  return username && password ? {password, username} : undefined;
+};
+
+/**
+ * Signs the user in right after a successful embedded registration, using the credentials they just
+ * submitted, through the app-native (embedded) sign-in flow. On success the session cookie is set exactly
+ * as for a regular sign-in.
+ *
+ * Returns `false` (without throwing) whenever an automatic sign-in is not possible, for example when
+ * app-native authentication is disabled for the application or the login flow needs more than a
+ * username/password step. The caller should then fall back to sending the user to the sign-in page.
+ */
+const autoSignInAfterSignUp = async ({username, password}: SignUpCredentials): Promise<boolean> => {
+  try {
+    const initiation: Awaited<ReturnType<typeof signInAction>> = await signInAction({
+      flowId: '',
+      selectedAuthenticator: {authenticatorId: '', params: {}},
+    });
+    const flow: EmbeddedSignInFlowInitiateResponse | undefined = initiation?.data as
+      | EmbeddedSignInFlowInitiateResponse
+      | undefined;
+
+    if (!initiation.success || !flow || !('nextStep' in flow)) {
+      logger.warn(
+        `[autoSignInAfterSignUp] Could not start the sign-in flow after registration, the user has to sign in manually. ${
+          initiation.error ?? ''
+        }`,
+      );
+
+      return false;
+    }
+
+    const basicAuthenticator: EmbeddedSignInFlowAuthenticator | undefined = flow.nextStep?.authenticators?.find(
+      (authenticator: EmbeddedSignInFlowAuthenticator) =>
+        authenticator.idp === 'LOCAL' &&
+        authenticator.requiredParams?.includes('username') &&
+        authenticator.requiredParams?.includes('password'),
+    );
+
+    if (!basicAuthenticator) {
+      logger.warn(
+        '[autoSignInAfterSignUp] The first login step has no username/password authenticator, the user has to sign in manually.',
+      );
+
+      return false;
+    }
+
+    const link: {href: string; method: string} | undefined = flow.links?.[0];
+    const completion: Awaited<ReturnType<typeof signInAction>> = await signInAction(
+      {
+        flowId: flow.flowId,
+        selectedAuthenticator: {authenticatorId: basicAuthenticator.authenticatorId, params: {password, username}},
+      },
+      link ? {method: link.method, url: link.href} : {},
+    );
+
+    if (completion.success && completion.data && 'afterSignInUrl' in completion.data) {
+      return true;
+    }
+
+    logger.warn(
+      `[autoSignInAfterSignUp] Sign-in did not complete in a single step (status: ${
+        (completion.data as {flowStatus?: string})?.flowStatus ?? 'unknown'
+      }), the user has to sign in manually. ${completion.error ?? ''}`,
+    );
+
+    return false;
+  } catch (error) {
+    logger.warn(
+      `[autoSignInAfterSignUp] Automatic sign-in failed, the user has to sign in manually: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return false;
+  }
+};
+
+export default autoSignInAfterSignUp;

--- a/packages/nextjs/src/utils/decorateConfigWithNextEnv.ts
+++ b/packages/nextjs/src/utils/decorateConfigWithNextEnv.ts
@@ -30,6 +30,7 @@ const decorateConfigWithNextEnv = (config: AsgardeoNextConfig): AsgardeoNextConf
     signUpUrl,
     afterSignInUrl,
     afterSignOutUrl,
+    afterSignUpUrl,
     sessionCookieExpiryTime,
     ...rest
   } = config;
@@ -38,6 +39,7 @@ const decorateConfigWithNextEnv = (config: AsgardeoNextConfig): AsgardeoNextConf
     ...rest,
     afterSignInUrl: afterSignInUrl || (process.env['NEXT_PUBLIC_ASGARDEO_AFTER_SIGN_IN_URL'] as string),
     afterSignOutUrl: afterSignOutUrl || (process.env['NEXT_PUBLIC_ASGARDEO_AFTER_SIGN_OUT_URL'] as string),
+    afterSignUpUrl: afterSignUpUrl || (process.env['NEXT_PUBLIC_ASGARDEO_AFTER_SIGN_UP_URL'] as string),
     applicationId: applicationId || (process.env['NEXT_PUBLIC_ASGARDEO_APPLICATION_ID'] as string),
     baseUrl: baseUrl || (process.env['NEXT_PUBLIC_ASGARDEO_BASE_URL'] as string),
     clientId: clientId || (process.env['NEXT_PUBLIC_ASGARDEO_CLIENT_ID'] as string),

--- a/packages/react/src/components/adapters/FormContainer.tsx
+++ b/packages/react/src/components/adapters/FormContainer.tsx
@@ -46,10 +46,11 @@ const FormContainer: FC<AdapterProps> = (props: AdapterProps) => {
 
     return (
       <form key={component.id} onSubmit={handleFormSubmit} style={{display: 'flex', flexDirection: 'column'}}>
-        {component.components.map((childComponent: any) =>
+        {component.components.map((childComponent: any, index: number) =>
           createSignUpComponent({
             ...props,
             component: childComponent,
+            key: childComponent.id || index,
           }),
         )}
       </form>

--- a/packages/react/src/components/presentation/UserProfile/BaseUserProfile.test.tsx
+++ b/packages/react/src/components/presentation/UserProfile/BaseUserProfile.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* eslint-disable sort-keys, @typescript-eslint/typedef, @typescript-eslint/explicit-function-return-type, testing-library/no-container, testing-library/no-node-access */
+
+import {cleanup, render} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import BaseUserProfile from './BaseUserProfile';
+
+// Mock theme data
+const mockColors = {
+  text: {primary: '#000', secondary: '#666'},
+  background: {surface: '#fff', disabled: '#eee', body: {main: '#fff'}},
+  border: '#ccc',
+  action: {
+    hover: '#f0f0f0',
+    active: '#e0e0e0',
+    selected: '#d0d0d0',
+    disabled: '#bbb',
+    disabledBackground: '#f5f5f5',
+    focus: '#0066cc',
+    hoverOpacity: 0.08,
+    selectedOpacity: 0.12,
+    disabledOpacity: 0.38,
+    focusOpacity: 0.12,
+    activatedOpacity: 0.12,
+  },
+  primary: {main: '#0066cc', contrastText: '#fff'},
+  secondary: {main: '#666', contrastText: '#fff'},
+  error: {main: '#d32f2f', contrastText: '#fff'},
+  success: {main: '#2e7d32', contrastText: '#fff'},
+  warning: {main: '#ed6c02', contrastText: '#fff'},
+  info: {main: '#0288d1', contrastText: '#fff'},
+};
+
+const mockTypography = {
+  fontFamily: 'Arial, sans-serif',
+  fontSizes: {
+    xs: '0.75rem',
+    sm: '0.875rem',
+    md: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem',
+    '2xl': '1.5rem',
+    '3xl': '1.875rem',
+  },
+  fontWeights: {normal: 400, medium: 500, semibold: 600, bold: 700},
+  lineHeights: {tight: 1.25, normal: 1.5, relaxed: 1.75},
+};
+
+const mockTypographyVars = {
+  fontFamily: 'Arial, sans-serif',
+  fontSizes: {
+    xs: '0.75rem',
+    sm: '0.875rem',
+    md: '1rem',
+    lg: '1.125rem',
+    xl: '1.25rem',
+    '2xl': '1.5rem',
+    '3xl': '1.875rem',
+  },
+  fontWeights: {normal: '400', medium: '500', semibold: '600', bold: '700'},
+  lineHeights: {tight: '1.25', normal: '1.5', relaxed: '1.75'},
+};
+
+const mockColorsVars = {
+  ...mockColors,
+  action: {
+    hover: '#f0f0f0',
+    active: '#e0e0e0',
+    selected: '#d0d0d0',
+    disabled: '#bbb',
+    disabledBackground: '#f5f5f5',
+    focus: '#0066cc',
+    hoverOpacity: '0.08',
+    selectedOpacity: '0.12',
+    disabledOpacity: '0.38',
+    focusOpacity: '0.12',
+    activatedOpacity: '0.12',
+  },
+};
+
+// Mock the dependencies
+vi.mock('../../../contexts/Theme/useTheme', () => ({
+  default: () => ({
+    theme: {
+      // ThemeConfig properties (direct access)
+      colors: mockColors,
+      typography: mockTypography,
+      spacing: {unit: 8},
+      borderRadius: {small: '2px', medium: '4px', large: '8px'},
+      shadows: {
+        small: '0 1px 2px rgba(0,0,0,0.1)',
+        medium: '0 2px 4px rgba(0,0,0,0.1)',
+        large: '0 4px 8px rgba(0,0,0,0.1)',
+      },
+      cssVariables: {},
+      // ThemeVars (CSS variable references)
+      vars: {
+        colors: mockColorsVars,
+        spacing: {unit: '8px'},
+        borderRadius: {small: '2px', medium: '4px', large: '8px'},
+        shadows: {
+          small: '0 1px 2px rgba(0,0,0,0.1)',
+          medium: '0 2px 4px rgba(0,0,0,0.1)',
+          large: '0 4px 8px rgba(0,0,0,0.1)',
+        },
+        typography: mockTypographyVars,
+      },
+    },
+    colorScheme: 'light',
+    direction: (document.documentElement.getAttribute('dir') as 'ltr' | 'rtl') || 'ltr',
+  }),
+}));
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  default: () => ({
+    t: (key: string) => key,
+    currentLanguage: 'en',
+    setLanguage: vi.fn(),
+    availableLanguages: ['en'],
+  }),
+}));
+
+const schemas: any[] = [
+  {name: 'userName', displayName: 'Username', type: 'STRING', mutability: 'readOnly', schemaId: 'core'},
+  {name: 'name.givenName', displayName: 'First Name', type: 'STRING', mutability: 'readWrite', schemaId: 'core'},
+  {name: 'name.familyName', displayName: 'Last Name', type: 'STRING', mutability: 'readWrite', schemaId: 'core'},
+  {name: 'emails', displayName: 'Email', type: 'STRING', mutability: 'readWrite', multiValued: true, schemaId: 'core'},
+];
+const flattenedProfile: any = {userName: 'omal@example.com', 'name.givenName': 'Omal', emails: ['omal@example.com']};
+const profile: any = {userName: 'omal@example.com', name: {givenName: 'Omal'}, emails: ['omal@example.com']};
+
+describe('BaseUserProfile with SCIM2 schemas', () => {
+  afterEach(() => cleanup());
+
+  it('treats camelCase SCIM mutability values like the upper-case ones', () => {
+    const {container} = render(
+      <BaseUserProfile
+        profile={profile}
+        flattenedProfile={flattenedProfile}
+        schemas={schemas}
+        editable
+        onUpdate={vi.fn()}
+      />,
+    );
+    const text: string = container.textContent || '';
+
+    // Fields with values are editable (username is always read-only).
+    expect(container.querySelectorAll('button[title="Edit"]').length).toBe(2);
+    // An empty readWrite field is still offered so the user can fill it in.
+    expect(text).toContain('Last Name');
+    expect(container.querySelector('button[title="Click to edit"]')).toBeTruthy();
+  });
+
+  it('hides empty fields when not editable', () => {
+    const {container} = render(
+      <BaseUserProfile profile={profile} flattenedProfile={flattenedProfile} schemas={schemas} editable={false} />,
+    );
+    const text: string = container.textContent || '';
+
+    expect(text).not.toContain('Last Name');
+    expect(container.querySelectorAll('button[title="Edit"]').length).toBe(0);
+  });
+});

--- a/packages/react/src/components/presentation/UserProfile/BaseUserProfile.tsx
+++ b/packages/react/src/components/presentation/UserProfile/BaseUserProfile.tsx
@@ -116,6 +116,14 @@ const fieldsToSkip: string[] = [
 // Fields that should be readonly
 const readonlyFields: string[] = ['username', 'userName', 'user_name'];
 
+/**
+ * SCIM2 schemas report mutability as `readWrite` / `readOnly` / `immutable` (camelCase), while some
+ * older payloads use `READ_WRITE` / `READ_ONLY`. Normalize so both are handled.
+ */
+const normalizeMutability = (mutability?: string): string => (mutability ?? '').replace(/_/g, '').toLowerCase();
+const isReadOnlyMutability = (mutability?: string): boolean => normalizeMutability(mutability) === 'readonly';
+const isReadWriteMutability = (mutability?: string): boolean => normalizeMutability(mutability) === 'readwrite';
+
 const BaseUserProfile: FC<BaseUserProfileProps> = ({
   fallback = null,
   className = '',
@@ -371,7 +379,7 @@ const BaseUserProfile: FC<BaseUserProfileProps> = ({
       const hasValues: any = Array.isArray(value)
         ? value.length > 0
         : value !== undefined && value !== null && value !== '';
-      const isEditable: any = editable && mutability !== 'READ_ONLY' && !readonlyFields.includes(name || '');
+      const isEditable: any = editable && !isReadOnlyMutability(mutability) && !readonlyFields.includes(name || '');
 
       if (isEditing && onEditValue && isEditable) {
         let currentValue: any;
@@ -456,7 +464,7 @@ const BaseUserProfile: FC<BaseUserProfileProps> = ({
       return <ObjectDisplay data={value} />;
     }
 
-    if (isEditing && onEditValue && mutability !== 'READ_ONLY' && !readonlyFields.includes(name || '')) {
+    if (isEditing && onEditValue && !isReadOnlyMutability(mutability) && !readonlyFields.includes(name || '')) {
       let fieldValue: any;
       if (editedUser && name && editedUser[name] !== undefined) {
         fieldValue = editedUser[name];
@@ -516,7 +524,7 @@ const BaseUserProfile: FC<BaseUserProfileProps> = ({
     }
 
     const hasValue: any = value !== undefined && value !== null && value !== '';
-    const isEditable: any = editable && mutability !== 'READ_ONLY' && !readonlyFields.includes(name || '');
+    const isEditable: any = editable && !isReadOnlyMutability(mutability) && !readonlyFields.includes(name || '');
 
     let displayValue: string;
     if (hasValue) {
@@ -557,7 +565,7 @@ const BaseUserProfile: FC<BaseUserProfileProps> = ({
     const isFieldEditing: any = editingFields[schema.name];
     const isReadonlyField: any = readonlyFields.includes(schema.name);
 
-    const shouldShow: any = hasValue || isFieldEditing || (editable && schema.mutability === 'READ_WRITE');
+    const shouldShow: any = hasValue || isFieldEditing || (editable && isReadWriteMutability(schema.mutability));
 
     if (!shouldShow) {
       return null;
@@ -577,7 +585,7 @@ const BaseUserProfile: FC<BaseUserProfileProps> = ({
             () => toggleFieldEdit(schema.name!),
           )}
         </div>
-        {editable && schema.mutability !== 'READ_ONLY' && !isReadonlyField && (
+        {editable && !isReadOnlyMutability(schema.mutability) && !isReadonlyField && (
           <div className={styles.fieldActions}>
             {isFieldEditing && (
               <>

--- a/packages/react/src/components/presentation/auth/Recovery/v1/RecoveryOptionFactory.tsx
+++ b/packages/react/src/components/presentation/auth/Recovery/v1/RecoveryOptionFactory.tsx
@@ -18,7 +18,7 @@
 
 import {EmbeddedFlowComponent, EmbeddedFlowComponentType} from '@asgardeo/browser';
 import {AdapterProps} from 'packages/react/src/models/adapters';
-import {ReactElement} from 'react';
+import {Key, ReactElement, cloneElement} from 'react';
 import CheckboxInput from '../../../../adapters/CheckboxInput';
 import DateInput from '../../../../adapters/DateInput';
 import DividerComponent from '../../../../adapters/DividerComponent';
@@ -41,9 +41,9 @@ import TextInput from '../../../../adapters/TextInput';
 import Typography from '../../../../adapters/Typography';
 
 /**
- * Creates the appropriate recovery component based on the component type.
+ * Builds the recovery element for a flow component. Keys are applied by `createRecoveryComponent`.
  */
-export const createRecoveryComponent = ({component, onSubmit, ...rest}: AdapterProps): ReactElement => {
+const createRecoveryElement = ({component, onSubmit, ...rest}: AdapterProps): ReactElement => {
   switch (component.type) {
     case EmbeddedFlowComponentType.Typography:
       return <Typography component={component} onSubmit={onSubmit} {...rest} />;
@@ -155,6 +155,18 @@ export const createRecoveryComponent = ({component, onSubmit, ...rest}: AdapterP
     default:
       return <div />;
   }
+};
+
+/**
+ * Creates the appropriate recovery component based on the component type.
+ *
+ * `key` is intentionally pulled out of the props and applied via `cloneElement`,
+ * because React does not allow `key` to be passed through a props spread.
+ */
+export const createRecoveryComponent = ({key, ...props}: AdapterProps & {key?: Key}): ReactElement => {
+  const element: ReactElement = createRecoveryElement(props);
+
+  return key === undefined || key === null ? element : cloneElement(element, {key});
 };
 
 /**

--- a/packages/react/src/components/presentation/auth/SignIn/v1/BaseSignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v1/BaseSignIn.tsx
@@ -24,7 +24,6 @@ import {
   EmbeddedSignInFlowStatus,
   EmbeddedSignInFlowAuthenticatorPromptType,
   ApplicationNativeAuthenticationConstants,
-  AsgardeoAPIError,
   withVendorCSSClassPrefix,
   EmbeddedSignInFlowHandleRequestPayload,
   EmbeddedFlowExecuteRequestConfig,
@@ -39,6 +38,7 @@ import useFlow from '../../../../../contexts/Flow/useFlow';
 import useTheme from '../../../../../contexts/Theme/useTheme';
 import {useForm, FormField} from '../../../../../hooks/useForm';
 import useTranslation from '../../../../../hooks/useTranslation';
+import resolveFlowErrorMessage from '../../../../../utils/resolveFlowErrorMessage';
 import AlertPrimitive, {AlertVariant} from '../../../../primitives/Alert/Alert';
 import CardPrimitive, {CardProps} from '../../../../primitives/Card/Card';
 import Divider from '../../../../primitives/Divider/Divider';
@@ -510,7 +510,7 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
         }
       }
     } catch (err) {
-      const errorMessage: string = err instanceof AsgardeoAPIError ? err.message : t('errors.signin.flow.failure');
+      const errorMessage: string = resolveFlowErrorMessage(err, t('errors.signin.flow.failure'));
       setError(errorMessage);
       onError?.(err as Error);
     } finally {
@@ -800,7 +800,7 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
         }
       }
     } catch (err) {
-      const errorMessage: string = err instanceof AsgardeoAPIError ? err?.message : 'Authenticator selection failed';
+      const errorMessage: string = resolveFlowErrorMessage(err, 'Authenticator selection failed');
       setError(errorMessage);
       onError?.(err as Error);
     } finally {
@@ -926,7 +926,7 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
           );
         }
       } catch (err) {
-        const errorMessage: string = err instanceof AsgardeoAPIError ? err.message : t('errors.signin.initialization');
+        const errorMessage: string = resolveFlowErrorMessage(err, t('errors.signin.initialization'));
         setError(errorMessage);
         onError?.(err as Error);
       } finally {

--- a/packages/react/src/components/presentation/auth/SignUp/v1/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v1/BaseSignUp.tsx
@@ -34,6 +34,7 @@ import useFlow from '../../../../../contexts/Flow/useFlow';
 import useTheme from '../../../../../contexts/Theme/useTheme';
 import {useForm, FormField} from '../../../../../hooks/useForm';
 import useTranslation from '../../../../../hooks/useTranslation';
+import resolveFlowErrorMessage from '../../../../../utils/resolveFlowErrorMessage';
 import AlertPrimitive from '../../../../primitives/Alert/Alert';
 // eslint-disable-next-line import/no-named-as-default
 import CardPrimitive, {CardProps} from '../../../../primitives/Card/Card';
@@ -220,6 +221,19 @@ export interface BaseSignUpProps {
  *
  * @internal
  */
+/**
+ * Maps a flow message type to an Alert variant, defaulting to `info` for unknown types.
+ */
+const resolveAlertVariant = (type?: string): 'success' | 'error' | 'warning' | 'info' => {
+  const normalized: string = type?.toLowerCase() ?? '';
+
+  if (normalized === 'success' || normalized === 'error' || normalized === 'warning') {
+    return normalized;
+  }
+
+  return 'info';
+};
+
 const BaseSignUpContent: FC<BaseSignUpProps> = ({
   afterSignUpUrl,
   onInitialize,
@@ -247,31 +261,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
   const handleError: any = useCallback(
     (error: any) => {
-      let errorMessage: string = t('errors.signup.flow.failure');
-
-      if (error && typeof error === 'object') {
-        // Handle Asgardeo error format with code and description/message
-        if (error.code && (error.message || error.description)) {
-          errorMessage = error.description || error.message;
-        } else if (error instanceof Error && error.name === 'AsgardeoAPIError') {
-          try {
-            const errorResponse: any = JSON.parse(error.message);
-            if (errorResponse.description) {
-              errorMessage = errorResponse.description;
-            } else if (errorResponse.message) {
-              errorMessage = errorResponse.message;
-            } else {
-              errorMessage = error.message;
-            }
-          } catch {
-            errorMessage = error.message;
-          }
-        } else if (error.message) {
-          errorMessage = error.message;
-        }
-      } else if (typeof error === 'string') {
-        errorMessage = error;
-      }
+      const errorMessage: string = resolveFlowErrorMessage(error, t('errors.signup.flow.failure'));
 
       // Clear existing messages and add the error message
       clearMessages();
@@ -285,9 +275,28 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
   const [isLoading, setIsLoading] = useState(false);
   const [isFlowInitialized, setIsFlowInitialized] = useState(false);
+  const [isFlowComplete, setIsFlowComplete] = useState(false);
   const [currentFlow, setCurrentFlow] = useState<EmbeddedFlowExecuteResponse | null>(null);
 
   const initializationAttemptedRef: any = useRef(false);
+
+  /**
+   * Marks the flow as complete: hides the form, shows a success message and notifies the host.
+   * Hosts that redirect afterwards (e.g. Next.js) still get a meaningful screen while navigation is in flight.
+   */
+  const handleFlowComplete: (response: EmbeddedFlowExecuteResponse) => void = useCallback(
+    (response: EmbeddedFlowExecuteResponse): void => {
+      setCurrentFlow(response);
+      setIsFlowComplete(true);
+      clearMessages();
+      addMessage({
+        message: t('signup.success'),
+        type: 'success',
+      });
+      onComplete?.(response);
+    },
+    [t, addMessage, clearMessages, onComplete],
+  );
 
   /**
    * Extract form fields from flow components
@@ -451,10 +460,17 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
           try {
             const continueResponse: any = await onSubmit(payload);
+
+            if (!continueResponse) {
+              popup.close();
+              cleanup();
+              return;
+            }
+
             onFlowChange?.(continueResponse);
 
             if (continueResponse.flowStatus === EmbeddedFlowStatus.Complete) {
-              onComplete?.(continueResponse);
+              handleFlowComplete(continueResponse);
             } else if (continueResponse.flowStatus === EmbeddedFlowStatus.Incomplete) {
               setCurrentFlow(continueResponse);
               setupFormFields(continueResponse);
@@ -522,10 +538,16 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
                 try {
                   const continueResponse: any = await onSubmit(payload);
+
+                  if (!continueResponse) {
+                    popup.close();
+                    return;
+                  }
+
                   onFlowChange?.(continueResponse);
 
                   if (continueResponse.flowStatus === EmbeddedFlowStatus.Complete) {
-                    onComplete?.(continueResponse);
+                    handleFlowComplete(continueResponse);
                   } else if (continueResponse.flowStatus === EmbeddedFlowStatus.Incomplete) {
                     setCurrentFlow(continueResponse);
                     setupFormFields(continueResponse);
@@ -586,10 +608,16 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
       } as any;
 
       const response: any = await onSubmit(payload);
+
+      // `onSubmit` may resolve without a response when the host has already taken over (e.g. a redirect).
+      if (!response) {
+        return;
+      }
+
       onFlowChange?.(response);
 
       if (response.flowStatus === EmbeddedFlowStatus.Complete) {
-        onComplete?.(response);
+        handleFlowComplete(response);
         return;
       }
 
@@ -600,6 +628,14 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
         setCurrentFlow(response);
         setupFormFields(response);
+
+        // Surface server-side validation failures (e.g. password policy) that arrive with an INCOMPLETE flow.
+        const flowError: unknown = response.data?.additionalData?.['error'];
+
+        if (flowError) {
+          clearMessages();
+          addMessage({message: String(flowError), type: 'error'});
+        }
       }
     } catch (err) {
       handleError(err);
@@ -687,12 +723,16 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         try {
           const response: any = await onInitialize();
 
+          if (!response) {
+            return;
+          }
+
           setCurrentFlow(response);
           setIsFlowInitialized(true);
           onFlowChange?.(response);
 
           if (response.flowStatus === EmbeddedFlowStatus.Complete) {
-            onComplete?.(response);
+            handleFlowComplete(response);
             return;
           }
 
@@ -711,7 +751,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
     isInitialized,
     isFlowInitialized,
     onInitialize,
-    onComplete,
+    handleFlowComplete,
     onError,
     onFlowChange,
     setupFormFields,
@@ -786,7 +826,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
             {flowMessages.map((message: any, index: number) => (
               <AlertPrimitive
                 key={message.id || index}
-                variant={message.type?.toLowerCase() === 'error' ? 'error' : 'info'}
+                variant={resolveAlertVariant(message.type)}
                 className={cx(styles.flowMessageItem, messageClasses)}
               >
                 <AlertPrimitive.Description>{message.message}</AlertPrimitive.Description>
@@ -794,15 +834,17 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
             ))}
           </div>
         )}
-        <div className={styles.contentContainer}>
-          {currentFlow.data?.components && currentFlow.data.components.length > 0 ? (
-            renderComponents(currentFlow.data.components)
-          ) : (
-            <AlertPrimitive variant="warning">
-              <Typography variant="body1">{t('errors.signup.components.not.available')}</Typography>
-            </AlertPrimitive>
-          )}
-        </div>
+        {!isFlowComplete && (
+          <div className={styles.contentContainer}>
+            {currentFlow.data?.components && currentFlow.data.components.length > 0 ? (
+              renderComponents(currentFlow.data.components)
+            ) : (
+              <AlertPrimitive variant="warning">
+                <Typography variant="body1">{t('errors.signup.components.not.available')}</Typography>
+              </AlertPrimitive>
+            )}
+          </div>
+        )}
       </CardPrimitive.Content>
     </CardPrimitive>
   );

--- a/packages/react/src/components/presentation/auth/SignUp/v1/SignUpOptionFactory.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v1/SignUpOptionFactory.tsx
@@ -18,7 +18,7 @@
 
 import {EmbeddedFlowComponent, EmbeddedFlowComponentType} from '@asgardeo/browser';
 import {AdapterProps} from 'packages/react/src/models/adapters';
-import {ReactElement} from 'react';
+import {Key, ReactElement, cloneElement} from 'react';
 import CheckboxInput from '../../../../adapters/CheckboxInput';
 import DateInput from '../../../../adapters/DateInput';
 import DividerComponent from '../../../../adapters/DividerComponent';
@@ -41,9 +41,9 @@ import TextInput from '../../../../adapters/TextInput';
 import Typography from '../../../../adapters/Typography';
 
 /**
- * Creates the appropriate sign-up component based on the component type.
+ * Builds the sign-up element for a flow component. Keys are applied by `createSignUpComponent`.
  */
-export const createSignUpComponent = ({component, onSubmit, ...rest}: AdapterProps): ReactElement => {
+const createSignUpElement = ({component, onSubmit, ...rest}: AdapterProps): ReactElement => {
   switch (component.type) {
     case EmbeddedFlowComponentType.Typography:
       return <Typography component={component} onSubmit={onSubmit} {...rest} />;
@@ -155,6 +155,18 @@ export const createSignUpComponent = ({component, onSubmit, ...rest}: AdapterPro
     default:
       return <div />;
   }
+};
+
+/**
+ * Creates the appropriate sign-up component based on the component type.
+ *
+ * `key` is intentionally pulled out of the props and applied via `cloneElement`,
+ * because React does not allow `key` to be passed through a props spread.
+ */
+export const createSignUpComponent = ({key, ...props}: AdapterProps & {key?: Key}): ReactElement => {
+  const element: ReactElement = createSignUpElement(props);
+
+  return key === undefined || key === null ? element : cloneElement(element, {key});
 };
 
 /**

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -728,6 +728,12 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
       } as any;
 
       const rawResponse: any = await onSubmit(payload);
+
+      // `onSubmit` may resolve without a response when the host has already taken over (e.g. a redirect).
+      if (!rawResponse) {
+        return;
+      }
+
       const response: any = normalizeFlowResponseLocal(rawResponse);
       onFlowChange?.(response);
 

--- a/packages/react/src/utils/resolveFlowErrorMessage.test.ts
+++ b/packages/react/src/utils/resolveFlowErrorMessage.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {describe, expect, it} from 'vitest';
+import resolveFlowErrorMessage from './resolveFlowErrorMessage';
+
+describe('resolveFlowErrorMessage', () => {
+  const FALLBACK: string = 'Something went wrong.';
+
+  it('returns the fallback for empty input', () => {
+    expect(resolveFlowErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(resolveFlowErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(resolveFlowErrorMessage(new Error(''), FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('extracts the description from an embedded JSON error payload', () => {
+    const error: Error = new Error(
+      'Authorization request failed: {"code":"ABA-60007","message":"App native authentication is not enabled for the application.","description":"App native authentication is not enabled for this application with id 6af54eb1"}',
+    );
+
+    expect(resolveFlowErrorMessage(error, FALLBACK)).toBe(
+      'App native authentication is not enabled for this application with id 6af54eb1',
+    );
+  });
+
+  it('handles errors serialized across a server action boundary', () => {
+    const error: Error = new Error(
+      '[AsgardeoAPIError] (code="initializeEmbeddedSignInFlow-ResponseError-001") (HTTP 400 - Bad Request)\nMessage: Authorization request failed: {"code":"ABA-60001","message":"Invalid authentication request.","description":"invalid_callback - callback.not.match"}',
+    );
+
+    expect(resolveFlowErrorMessage(error, FALLBACK)).toBe('invalid_callback - callback.not.match');
+  });
+
+  it('falls back to the message field when there is no description', () => {
+    expect(resolveFlowErrorMessage(new Error('Failed: {"code":"X","message":"Flow is disabled."}'), FALLBACK)).toBe(
+      'Flow is disabled.',
+    );
+  });
+
+  it('strips the serialized preamble when the message is not JSON', () => {
+    expect(
+      resolveFlowErrorMessage(new Error('[AsgardeoAPIError] (code="x")\nMessage: Network or parsing error'), FALLBACK),
+    ).toBe('Network or parsing error');
+  });
+
+  it('accepts plain error objects and strings', () => {
+    expect(resolveFlowErrorMessage({code: 'FEE-1', description: 'Provisioning failed.'}, FALLBACK)).toBe(
+      'Provisioning failed.',
+    );
+    expect(resolveFlowErrorMessage({code: 'FEE-1', message: 'Only message.'}, FALLBACK)).toBe('Only message.');
+    expect(resolveFlowErrorMessage('Plain text error', FALLBACK)).toBe('Plain text error');
+  });
+});

--- a/packages/react/src/utils/resolveFlowErrorMessage.ts
+++ b/packages/react/src/utils/resolveFlowErrorMessage.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Extracts a human-readable message from an error raised by an embedded flow call.
+ *
+ * Handles:
+ * - `AsgardeoAPIError` (and any `Error`) whose message embeds the server's JSON error payload,
+ *   e.g. `Authorization request failed: {"code":"ABA-60007","message":"...","description":"..."}`.
+ * - Errors that crossed a serialization boundary (such as a Next.js server action) and arrive as a plain
+ *   `Error` whose message is the stringified API error:
+ *   `[AsgardeoAPIError] (code="...") (HTTP 400 - Bad Request)\nMessage: ...`.
+ * - Plain objects carrying `description` / `message` fields, and raw strings.
+ *
+ * @param error - The caught error.
+ * @param fallback - Message to use when nothing meaningful can be extracted.
+ * @returns A message suitable for showing to the user.
+ */
+const resolveFlowErrorMessage = (error: unknown, fallback: string): string => {
+  let raw: string = '';
+
+  if (error instanceof Error) {
+    raw = error.message;
+  } else if (typeof error === 'string') {
+    raw = error;
+  } else if (error && typeof error === 'object') {
+    const {description, message}: {description?: unknown; message?: unknown} = error as Record<string, unknown>;
+
+    raw = (typeof description === 'string' && description) || (typeof message === 'string' && message) || '';
+  }
+
+  if (!raw) {
+    return fallback;
+  }
+
+  // Prefer the description or message of a JSON error payload embedded in the text.
+  const jsonStart: number = raw.indexOf('{');
+  const jsonEnd: number = raw.lastIndexOf('}');
+
+  if (jsonStart !== -1 && jsonEnd > jsonStart) {
+    try {
+      const payload: {description?: unknown; message?: unknown} = JSON.parse(raw.slice(jsonStart, jsonEnd + 1));
+      const extracted: unknown = payload?.description || payload?.message;
+
+      if (typeof extracted === 'string' && extracted) {
+        return extracted;
+      }
+    } catch {
+      // Not JSON, fall through.
+    }
+  }
+
+  // Strip the serialized `AsgardeoError` preamble, keeping only what follows `Message:`.
+  const messagePart: RegExpMatchArray | null = raw.match(/Message:\s*([\s\S]+)$/);
+
+  if (messagePart?.[1]?.trim()) {
+    return messagePart[1].trim();
+  }
+
+  return raw;
+};
+
+export default resolveFlowErrorMessage;


### PR DESCRIPTION
## Purpose

Fixes the `<SignUp />` runtime error reported against `@asgardeo/nextjs` after a successful self-registration:

```
TypeError: Cannot read properties of undefined (reading 'flowStatus')
    at Object.handleSubmit [as onSubmit] (BaseSignUp.tsx:592:9)
```

and the related problems found while reproducing it against a real tenant with the app-native (embedded) components: no automatic sign-in after registration, the `afterSignInUrl` prop being ignored, no `http` client on `useAsgardeo()`, and `<UserProfile />` silently degrading when the SCIM2 profile cannot be loaded.

## Root causes

- On a completed registration the Next.js client provider pushed the router to `afterSignInUrl` and returned `undefined` to the form, which then read `.flowStatus` on it.
- The sign-up action never established a session, so the redirect target bounced when it was protected.
- The server `<AsgardeoProvider>` destructured `afterSignInUrl` / `afterSignOutUrl` out of the props and never passed them to `initialize`.
- `createRouteMatcher` escaped the dot inside `(.*)` before handling the group, so `/dashboard(.*)` never matched `/dashboard`.
- `<UserProfile />` compared SCIM mutability against `READ_WRITE` while tenants return `readWrite`, and the Next.js client fell back to ID-token claims without any log when SCIM2 `/Me` failed (typically a missing `internal_login` scope).

## Changes

**@asgardeo/react**
- Guard sign-up components against an empty submit/initialise result; show a success message once registration completes; surface `additionalData.error` (e.g. password policy) from incomplete flows.
- New `resolveFlowErrorMessage` util so sign-in/sign-up show the real server error, including errors serialised across a server action boundary.
- Fix React `key` warnings in the sign-up/recovery renderers and `FormContainer`.
- `<UserProfile />`: normalise mutability values.

**@asgardeo/nextjs**
- Sign-up action returns the completed flow + `afterSignUpUrl` (+ `signedIn`); the client provider hands the response back to the component and calls `router.refresh()` when a session was created.
- Automatic sign-in after registration through the app-native sign-in flow (`utils/autoSignInAfterSignUp.ts`), with graceful fallback and warnings when not possible.
- New `afterSignUpUrl` config / `NEXT_PUBLIC_ASGARDEO_AFTER_SIGN_UP_URL`, falling back to `afterSignInUrl`; the `<SignUp afterSignUpUrl>` prop now overrides it.
- `afterSignInUrl` / `afterSignOutUrl` provider props are applied; relative values are resolved against the app origin.
- `useAsgardeo().http.request` / `requestAll` backed by `httpRequestAction`; the token stays on the server and only the identity server and the app's own origin may be targeted.
- Actionable warning when the profile falls back to ID-token claims.
- `createRouteMatcher` wildcard fix.

**@asgardeo/javascript**
- `afterSignUpUrl` in the base config; sign-out URL resolution loads provider metadata on demand.

**@asgardeo/i18n**
- `signup.success` in all locales.

## Verification

- Unit tests added for `resolveFlowErrorMessage`, `BaseUserProfile` mutability handling, `extractSignUpCredentials`, and `httpRequestAction` (incl. origin allow-list). Full suites pass: javascript 462, nextjs 56, react 13, i18n 10.
- Verified end to end against a real tenant with a Next.js 15 app and with the reporter's Next.js 16 app: sign-up → automatic sign-in → protected dashboard; profile page shows SCIM attributes with edit affordances; `http.request` to `/scim2/Me` returns 200; sign-out clears the session and redirects.

## Notes for reviewers

- Auto sign-in requires app-native authentication to be enabled for the application; otherwise the SDK logs why and falls back to a plain redirect.
- Sign-out now performs a real logout at the identity server, so the post-logout URL (default: app origin) must be a registered callback URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable post-sign-up navigation, including Next.js environment variable support.
  * Sign-up now displays a localized success message and can automatically sign users in.
  * Added authenticated HTTP request utilities for Next.js applications.
  * Added support for camelCase profile field mutability values.

* **Bug Fixes**
  * Prevented sign-up crashes and improved handling of empty responses and server errors.
  * Fixed wildcard route matching and sign-out URL generation.
  * Improved error messages in sign-in and sign-up flows.
  * Added warnings when profile loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->