### PR TITLE
fix(react): focus the dialog on open instead of the hidden trigger

### DIFF
--- a/.changeset/dialog-initial-focus.md
+++ b/.changeset/dialog-initial-focus.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Dialogs (for example the popup mode of `<UserProfile />` opened from the user dropdown) now move focus onto the dialog when they open. Previously focus stayed on the trigger, which the focus manager had just hidden from assistive technology with `aria-hidden`, and browsers reported "Blocked aria-hidden on an element because its descendant retained focus".

--- a/packages/react/src/components/primitives/Dialog/Dialog.tsx
+++ b/packages/react/src/components/primitives/Dialog/Dialog.tsx
@@ -188,9 +188,17 @@ export const DialogContent: ForwardRefExoticComponent<HTMLProps<HTMLDivElement> 
             className={cx(withVendorCSSClassPrefix(bem('dialog', 'overlay')), styles['overlay'])}
             lockScroll
           >
-            <FloatingFocusManager context={floatingContext} initialFocus={-1}>
+            {/*
+              Move focus onto the dialog itself when it opens. The focus manager marks everything outside the
+              dialog `aria-hidden`, so leaving focus on the trigger (e.g. the user dropdown in a page header)
+              hides a focused element from assistive technology, which browsers flag as an accessibility error.
+              Focusing the container rather than the first field keeps the previous behaviour of not
+              auto-focusing an input.
+            */}
+            <FloatingFocusManager context={floatingContext} initialFocus={context.refs.floating}>
               <div
                 ref={ref}
+                tabIndex={-1}
                 className={cx(withVendorCSSClassPrefix(bem('dialog', 'content')), styles['content'], props.className)}
                 aria-labelledby={context.labelId}
                 aria-describedby={context.descriptionId}


### PR DESCRIPTION
## Purpose

Opening the profile popup from the user dropdown logged a browser accessibility error: "Blocked aria-hidden on an element because its descendant retained focus".

## Cause

The dialog's `FloatingFocusManager` marks everything outside the dialog `aria-hidden`, but `initialFocus={-1}` left focus on the trigger button inside the now-hidden page header.

## Change

Focus the dialog container itself when it opens (`initialFocus={context.refs.floating}` plus `tabIndex={-1}` on the content). The first input is still not auto-focused.

## Testing

- React unit tests pass.
- Verified in the reporter's Next.js app: with the released 0.25.9 the focused element after opening the profile popup is the dropdown trigger outside the dialog; with this change it is the dialog content.