### PR TITLE
fix(nextjs): update organizations through a server action

### DIFF
--- a/.changeset/nextjs-organization-profile-update.md
+++ b/.changeset/nextjs-organization-profile-update.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/nextjs': patch
+---
+
+Editing an organization through `<OrganizationProfile />` works. The component called the Organizations API from the browser without an access token (the token lives in the HttpOnly session cookie), so every save was rejected. Updates now go through a server action (`updateOrganizationAction`, backed by `AsgardeoNextClient.updateOrganization()`) that attaches the token on the server, and a failed save surfaces its reason instead of a bare request error.

--- a/packages/nextjs/src/AsgardeoNextClient.ts
+++ b/packages/nextjs/src/AsgardeoNextClient.ts
@@ -39,6 +39,7 @@ import {
   Storage,
   TokenExchangeRequestConfig,
   TokenResponse,
+  UpdateOrganizationConfig,
   User,
   UserProfile,
   createOrganization,
@@ -56,6 +57,7 @@ import {
   getSchemas,
   initializeEmbeddedSignInFlow,
   updateMeProfile,
+  updateOrganization,
 } from '@asgardeo/node';
 import {AsgardeoNextConfig} from './models/config';
 import getClientOrigin from './server/actions/getClientOrigin';
@@ -338,6 +340,45 @@ class AsgardeoNextClient<T extends AsgardeoNextConfig = AsgardeoNextConfig> exte
         'AsgardeoReactClient-getOrganization-RuntimeError-001',
         'nextjs',
         `An error occurred while fetching the organization with the id: ${organizationId}.`,
+      );
+    }
+  }
+
+  /**
+   * Updates an organization with a set of patch operations, using the access token of the session.
+   *
+   * @param organizationId - The ID of the organization to update.
+   * @param operations - The patch operations to apply.
+   * @param userId - Optional session ID.
+   * @returns The updated organization.
+   */
+  async updateOrganization(
+    organizationId: string,
+    operations: UpdateOrganizationConfig['operations'],
+    userId?: string,
+  ): Promise<OrganizationDetails> {
+    try {
+      const configData: AuthClientConfig<T> = await this.asgardeo.getConfigData();
+      const baseUrl: string = configData?.baseUrl as string;
+
+      const organization: OrganizationDetails = await updateOrganization({
+        baseUrl,
+        headers: {
+          Authorization: `Bearer ${await this.getAccessToken(userId)}`,
+        },
+        operations,
+        organizationId,
+      });
+
+      return organization;
+    } catch (error) {
+      throw new AsgardeoRuntimeError(
+        `Failed to update the organization ${organizationId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+        'AsgardeoNextClient-updateOrganization-RuntimeError-001',
+        'nextjs',
+        `An error occurred while updating the organization with the id: ${organizationId}.`,
       );
     }
   }

--- a/packages/nextjs/src/client/components/presentation/OrganizationProfile/OrganizationProfile.tsx
+++ b/packages/nextjs/src/client/components/presentation/OrganizationProfile/OrganizationProfile.tsx
@@ -18,11 +18,12 @@
 
 'use client';
 
-import {OrganizationDetails, updateOrganization, createPatchOperations} from '@asgardeo/node';
+import {OrganizationDetails, createPatchOperations} from '@asgardeo/node';
 import {BaseOrganizationProfile, BaseOrganizationProfileProps, useTranslation} from '@asgardeo/react';
 import {FC, ReactElement, useEffect, useState} from 'react';
 import getOrganizationAction from '../../../../server/actions/getOrganizationAction';
 import getSessionId from '../../../../server/actions/getSessionId';
+import updateOrganizationAction from '../../../../server/actions/updateOrganizationAction';
 import logger from '../../../../utils/logger';
 import useAsgardeo from '../../../contexts/Asgardeo/useAsgardeo';
 
@@ -188,11 +189,15 @@ const OrganizationProfile: FC<OrganizationProfileProps> = ({
       const operations: Array<{operation: 'REPLACE' | 'REMOVE'; path: string; value?: any}> =
         createPatchOperations(payload);
 
-      await updateOrganization({
-        baseUrl,
-        operations,
-        organizationId,
-      });
+      // The access token only exists on the server (HttpOnly session cookie), so the update goes through
+      // a server action rather than calling the Organizations API from the browser.
+      const result: {data: {organization?: OrganizationDetails}; error: string | null; success: boolean} =
+        await updateOrganizationAction(organizationId, operations, (await getSessionId()) as string);
+
+      if (!result.success) {
+        throw new Error(result.error ?? 'Failed to update organization');
+      }
+
       // Refetch organization data after update
       await fetchOrganization();
 

--- a/packages/nextjs/src/server/actions/__tests__/updateOrganizationAction.test.ts
+++ b/packages/nextjs/src/server/actions/__tests__/updateOrganizationAction.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {beforeEach, describe, expect, it, vi, Mock} from 'vitest';
+import AsgardeoNextClient from '../../../AsgardeoNextClient';
+import updateOrganizationAction from '../updateOrganizationAction';
+
+vi.mock('../../../AsgardeoNextClient', () => ({
+  default: {
+    getInstance: vi.fn(),
+  },
+}));
+
+describe('updateOrganizationAction', () => {
+  type ActionResult = Awaited<ReturnType<typeof updateOrganizationAction>>;
+
+  const client: {updateOrganization: Mock} = {updateOrganization: vi.fn()};
+  const operations: Array<{operation: 'REPLACE'; path: string; value: string}> = [
+    {operation: 'REPLACE', path: '/name', value: 'Acme Inc.'},
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (AsgardeoNextClient.getInstance as unknown as Mock).mockReturnValue(client);
+  });
+
+  it('returns the updated organization when the update succeeds', async () => {
+    const organization: Record<string, unknown> = {id: 'org-1', name: 'Acme Inc.'};
+
+    client.updateOrganization.mockResolvedValue(organization);
+
+    const result: ActionResult = await updateOrganizationAction('org-1', operations, 'session-1');
+
+    expect(client.updateOrganization).toHaveBeenCalledWith('org-1', operations, 'session-1');
+    expect(result).toEqual({data: {organization}, error: null, success: true});
+  });
+
+  it('reports the failure reason instead of throwing when the update fails', async () => {
+    client.updateOrganization.mockRejectedValue(new Error('Failed to update the organization org-1: forbidden'));
+
+    const result: ActionResult = await updateOrganizationAction('org-1', operations);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Failed to update the organization org-1: forbidden');
+    expect(result.data.organization).toBeUndefined();
+  });
+});

--- a/packages/nextjs/src/server/actions/updateOrganizationAction.ts
+++ b/packages/nextjs/src/server/actions/updateOrganizationAction.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use server';
+
+import {OrganizationDetails, UpdateOrganizationConfig} from '@asgardeo/node';
+import AsgardeoNextClient from '../../AsgardeoNextClient';
+
+/**
+ * Server action to update an organization with a set of patch operations.
+ *
+ * The access token stays on the server: it is read from the session cookie and attached to the request,
+ * which is why the browser cannot call the Organizations API directly.
+ *
+ * @param organizationId - The ID of the organization to update.
+ * @param operations - The patch operations to apply (see `createPatchOperations`).
+ * @param sessionId - Optional session ID; resolved from the session cookie when omitted.
+ */
+const updateOrganizationAction = async (
+  organizationId: string,
+  operations: UpdateOrganizationConfig['operations'],
+  sessionId?: string,
+): Promise<{
+  data: {organization?: OrganizationDetails};
+  error: string | null;
+  success: boolean;
+}> => {
+  try {
+    const client: AsgardeoNextClient = AsgardeoNextClient.getInstance();
+    const organization: OrganizationDetails = await client.updateOrganization(organizationId, operations, sessionId);
+
+    return {data: {organization}, error: null, success: true};
+  } catch (error) {
+    return {
+      data: {},
+      error: error instanceof Error ? error.message : String(error),
+      success: false,
+    };
+  }
+};
+
+export default updateOrganizationAction;


### PR DESCRIPTION
## Problem

`<OrganizationProfile />` loads the organization through `getOrganizationAction`, but saves it by calling `updateOrganization()` from `@asgardeo/node` directly in the browser. The access token only exists in the HttpOnly session cookie on the server, so that request carries no `Authorization` header and is rejected every time; the component's editing feature could not work.

## Fix

- `AsgardeoNextClient.updateOrganization(organizationId, operations, sessionId?)` calls the Organizations API with the session's access token, like `getOrganization` / `createOrganization`.
- New server action `updateOrganizationAction` wraps it and reports failures as a result.
- `OrganizationProfile` sends its patch operations through the action and throws the reported reason on failure, so `BaseOrganizationProfile` shows it.

## Testing

- New `updateOrganizationAction` unit tests (success and failure results); 62 tests pass.
- `pnpm lint` and `tsc --noEmit` for `@asgardeo/nextjs`. There is no component test setup in this package.

Changeset included (`@asgardeo/nextjs` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization profile changes are now saved securely through a server-side update flow.
  - Successful updates return the latest organization details.
  - Save failures now display the underlying error reason to help users understand what went wrong.

- **Bug Fixes**
  - Improved organization update handling by ensuring session credentials are applied during saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->