### PR TITLE
fix(nextjs): refresh the organization list after an organization is created

### DIFF
--- a/.changeset/nextjs-revalidate-organizations.md
+++ b/.changeset/nextjs-revalidate-organizations.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/nextjs': patch
+---
+
+The organization list refreshes after an organization is created. `AsgardeoProvider` never passed a `revalidateMyOrganizations` function to the organization context, so `<CreateOrganization />` skipped the refresh and the switcher kept showing the old list until the page was reloaded. The provider now re-fetches the user's organizations through the `getMyOrganizations` server action and stores the result, as the React SDK does.

--- a/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -78,7 +78,11 @@ export type AsgardeoClientProviderProps = Partial<Omit<AsgardeoProviderProps, 'b
     myOrganizations: Organization[];
     organizationHandle: AsgardeoContextProps['organizationHandle'];
     refreshToken: () => Promise<RefreshResult>;
-    revalidateMyOrganizations?: (sessionId?: string) => Promise<Organization[]>;
+    /**
+     * Server action that re-fetches the organizations of the signed-in user (same signature as the
+     * `getMyOrganizations` action). The provider stores the result so every consumer sees the new list.
+     */
+    revalidateMyOrganizations?: (options?: any, sessionId?: string) => Promise<Organization[]>;
     signIn: AsgardeoContextProps['signIn'];
     signOut: AsgardeoContextProps['signOut'];
     signUp: AsgardeoContextProps['signUp'];
@@ -111,7 +115,7 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
   updateProfile,
   applicationId,
   organizationHandle,
-  myOrganizations,
+  myOrganizations: _myOrganizations,
   revalidateMyOrganizations,
   getAllOrganizations,
   switchOrganization,
@@ -125,10 +129,15 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [user, setUser] = useState<User | null>(_user);
   const [userProfile, setUserProfile] = useState<UserProfile>(_userProfile);
+  const [myOrganizations, setMyOrganizations] = useState<Organization[]>(_myOrganizations);
 
   useEffect(() => {
     setUserProfile(_userProfile);
   }, [_userProfile]);
+
+  useEffect(() => {
+    setMyOrganizations(_myOrganizations);
+  }, [_myOrganizations]);
 
   useEffect(() => {
     setUser(_user);
@@ -397,6 +406,22 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
     }));
   };
 
+  /**
+   * Re-fetches the user's organizations through the server action and stores them, so components such as
+   * `CreateOrganization` and `OrganizationSwitcher` reflect a newly created organization without a reload.
+   */
+  const handleRevalidateMyOrganizations = async (): Promise<Organization[]> => {
+    if (!revalidateMyOrganizations) {
+      return myOrganizations;
+    }
+
+    const organizations: Organization[] = await revalidateMyOrganizations();
+
+    setMyOrganizations(organizations);
+
+    return organizations;
+  };
+
   return (
     <AsgardeoContext.Provider value={contextValue}>
       <I18nProvider preferences={preferences?.i18n}>
@@ -414,7 +439,7 @@ const AsgardeoClientProvider: FC<PropsWithChildren<AsgardeoClientProviderProps>>
                   myOrganizations={myOrganizations}
                   currentOrganization={currentOrganization}
                   onOrganizationSwitch={switchOrganization as any}
-                  revalidateMyOrganizations={revalidateMyOrganizations as any}
+                  revalidateMyOrganizations={handleRevalidateMyOrganizations}
                 >
                   {children}
                 </OrganizationProvider>

--- a/packages/nextjs/src/server/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/server/AsgardeoProvider.tsx
@@ -235,6 +235,7 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
       updateProfile={updateUserProfileAction}
       isSignedIn={signedIn}
       myOrganizations={myOrganizations}
+      revalidateMyOrganizations={getMyOrganizations}
       getAllOrganizations={getAllOrganizations}
       switchOrganization={switchOrganization}
       brandingPreference={brandingPreference}


### PR DESCRIPTION
## Problem

`OrganizationProvider` expects a `revalidateMyOrganizations` function, and `<CreateOrganization />` calls it after a successful creation so the organization list reflects the new organization. The Next.js server provider never passed one (the client provider forwarded `undefined as any`), so the refresh was skipped and `<OrganizationSwitcher />` kept showing the old list until the page was reloaded. The React SDK re-fetches the list.

## Fix

- `AsgardeoServerProvider` passes the existing `getMyOrganizations` server action as `revalidateMyOrganizations`.
- `AsgardeoClientProvider` keeps `myOrganizations` in state (initialised from and synced with the server-provided list) and, when revalidation is requested, calls the action and stores the result so every consumer of the organization context sees the new list.

## Testing

- `pnpm lint`, `tsc --noEmit` and `pnpm vitest run` (60 tests) for `@asgardeo/nextjs`. There is no component test setup in this package, so the provider change is covered by review.

Changeset included (`@asgardeo/nextjs` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
