### PR TITLE
fix(nextjs): null user/organization while signed out and ID token fallback without profile fetching

### DIFF
--- a/.changeset/nextjs-signed-out-defaults.md
+++ b/.changeset/nextjs-signed-out-defaults.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/nextjs': patch
+---
+
+`useAsgardeo().user` and the current organization are `null` instead of empty objects while signed out or unavailable, so `<User fallback>` and `<Organization fallback>` render their fallbacks and `OrganizationSwitcher` no longer offers to manage an organization with an empty ID. With `preferences.user.fetchUserProfile` set to `false`, the user and profile are now populated from the ID token claims, as in the React SDK, instead of being left empty.

--- a/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -66,7 +66,7 @@ export type AsgardeoClientProviderProps = Partial<Omit<AsgardeoProviderProps, 'b
     brandingPreference?: BrandingPreference | null;
     clearSession: () => Promise<void>;
     createOrganization: (payload: CreateOrganizationPayload, sessionId: string) => Promise<Organization>;
-    currentOrganization: Organization;
+    currentOrganization: Organization | null;
     getAllOrganizations: (options?: any, sessionId?: string) => Promise<AllOrganizationsApiResponse>;
     handleOAuthCallback: (
       code: string,

--- a/packages/nextjs/src/server/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/server/AsgardeoProvider.tsx
@@ -18,7 +18,15 @@
 
 'use server';
 
-import {BrandingPreference, AsgardeoRuntimeError, IdToken, Organization, User, UserProfile} from '@asgardeo/node';
+import {
+  BrandingPreference,
+  AsgardeoRuntimeError,
+  IdToken,
+  Organization,
+  User,
+  UserProfile,
+  extractUserClaimsFromIdToken,
+} from '@asgardeo/node';
 import {AsgardeoProviderProps} from '@asgardeo/react';
 import {FC, PropsWithChildren, ReactElement} from 'react';
 import clearSession from './actions/clearSession';
@@ -116,17 +124,15 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
   const sessionId: string = sessionPayload?.sessionId || (await getSessionId()) || '';
   const signedIn: boolean = await isSignedIn(sessionId);
 
-  let user: User = {};
+  // `null` (not an empty object) while signed out or unavailable, so that `<User>` / `<Organization>` render
+  // their fallbacks and `useAsgardeo().user` can be checked for truthiness, as in the React SDK.
+  let user: User | null = null;
   let userProfile: UserProfile = {
     flattenedProfile: {},
     profile: {},
     schemas: [],
   };
-  let currentOrganization: Organization = {
-    id: '',
-    name: '',
-    orgHandle: '',
-  };
+  let currentOrganization: Organization | null = null;
   let myOrganizations: Organization[] = [];
   let brandingPreference: BrandingPreference | null = null;
 
@@ -166,10 +172,21 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
           success: boolean;
         } = await getUserProfileAction(sessionId);
 
-        user = userResponse.data?.user || {};
+        user = userResponse.data?.user ?? null;
         userProfile = userProfileResponse.data?.userProfile ?? userProfile;
       } catch (error) {
         logger.warn('[AsgardeoServerProvider] Failed to fetch user profile from SCIM2:', error?.toString());
+      }
+    } else {
+      // Profile fetching is disabled: expose the claims of the ID token instead, as the React SDK does, so
+      // that `user` and `<UserProfile />` are not empty.
+      try {
+        const claims: User = extractUserClaimsFromIdToken(await asgardeoClient.getDecodedIdToken(sessionId)) as User;
+
+        user = claims;
+        userProfile = {flattenedProfile: claims, profile: claims, schemas: []};
+      } catch (error) {
+        logger.warn('[AsgardeoServerProvider] Failed to read the user claims from the ID token:', error?.toString());
       }
     }
 
@@ -187,7 +204,7 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
           logger.warn('[AsgardeoServerProvider] No session ID available, skipping organization fetch');
         }
 
-        currentOrganization = currentOrganizationResponse?.data?.organization as Organization;
+        currentOrganization = currentOrganizationResponse?.data?.organization ?? null;
       } catch (error) {
         logger.warn('[AsgardeoServerProvider] Failed to fetch organization info:', error?.toString());
       }


### PR DESCRIPTION
## Problem

- `AsgardeoServerProvider` initialised `user` with `{}` and `currentOrganization` with `{id: '', name: '', orgHandle: ''}`. Both are truthy, so `<User fallback={...}>` and `<Organization fallback={...}>` never rendered their fallbacks while signed out, `useAsgardeo().user` could not be checked for truthiness, and `<OrganizationSwitcher />` showed a "manage organization" entry for an organization with an empty ID whenever the organization lookup failed. The React SDK keeps both `null` until they are known.
- With `preferences.user.fetchUserProfile: false` the Next.js provider left the user and profile empty; the React SDK falls back to the claims of the ID token.

## Fix

- `user` and `currentOrganization` default to `null` (the client provider prop type follows).
- When profile fetching is disabled, the user and profile are populated from the ID token claims (`extractUserClaimsFromIdToken`), mirroring the React SDK.

## Testing

- `pnpm lint`, `tsc --noEmit` and `pnpm vitest run` (60 tests) for `@asgardeo/nextjs`. The provider change is covered by review; there is no component test setup in this package.

Changeset included (`@asgardeo/nextjs` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
